### PR TITLE
Added swagger errors to lookup table

### DIFF
--- a/lib/ruby_claim_evidence_api/error.rb
+++ b/lib/ruby_claim_evidence_api/error.rb
@@ -11,5 +11,7 @@ module ClaimEvidenceApi
     class ClaimEvidenceInternalServerError < ClaimEvidenceApiError; end
     class ClaimEvidenceRateLimitError < ClaimEvidenceApiError; end
     class ClaimEvidenceNotImplementedError < ClaimEvidenceApiError; end
+    class ClaimEvidenceMediaTypeError < ClaimEvidenceApiError; end
+    class ClaimEvidenceBadRequestError < ClaimEvidenceApiError; end
   end
 end

--- a/lib/ruby_claim_evidence_api/external_api/response.rb
+++ b/lib/ruby_claim_evidence_api/external_api/response.rb
@@ -44,8 +44,8 @@ module ExternalApi
     # Error codes and their associated error
     ERROR_LOOKUP = {
       400 => ClaimEvidenceApi::Error::ClaimEvidenceBadRequestError,
-      401 => ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError,
-      403 => ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError,
+      401 => ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError,
+      403 => ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError,
       404 => ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError,
       415 => ClaimEvidenceApi::Error::ClaimEvidenceMediaTypeError,
       429 => ClaimEvidenceApi::Error::ClaimEvidenceRateLimitError,

--- a/lib/ruby_claim_evidence_api/external_api/response.rb
+++ b/lib/ruby_claim_evidence_api/external_api/response.rb
@@ -43,9 +43,11 @@ module ExternalApi
 
     # Error codes and their associated error
     ERROR_LOOKUP = {
-      401 => ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError,
-      403 => ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError,
+      400 => ClaimEvidenceApi::Error::ClaimEvidenceBadRequestError,
+      401 => ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError,
+      403 => ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError,
       404 => ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError,
+      415 => ClaimEvidenceApi::Error::ClaimEvidenceMediaTypeError,
       429 => ClaimEvidenceApi::Error::ClaimEvidenceRateLimitError,
       500 => ClaimEvidenceApi::Error::ClaimEvidenceInternalServerError,
       501 => ClaimEvidenceApi::Error::ClaimEvidenceNotImplementedError,


### PR DESCRIPTION
Resolves [APPEALS-46542](https://jira.devops.va.gov/browse/APPEALS-46542)

Added errors codes from Claim Evidence swagger for GetDocumentContent