### PR TITLE
Kev ma/error handling v1

### DIFF
--- a/lib/ruby_claim_evidence_api/external_api/response.rb
+++ b/lib/ruby_claim_evidence_api/external_api/response.rb
@@ -85,7 +85,8 @@ module ExternalApi
           body['message'] || body['messages'] || body['errors'][0]['message']
         end
       rescue StandardError => e
-        "Encountered #{e} while attempting to access response body: #{body}"
+        logger.error "Error accessing response body: #{body}"
+        "Encountered #{e} while attempting to access response body"
       end
     end
   end

--- a/lib/ruby_claim_evidence_api/external_api/response.rb
+++ b/lib/ruby_claim_evidence_api/external_api/response.rb
@@ -84,8 +84,7 @@ module ExternalApi
           body['message'] || body['messages'] || body['errors'][0]['message']
         end
       rescue StandardError => e
-        logger.error "Encountered #{e} while attempting to access response body: #{body}"
-        {}
+        "Encountered #{e} while attempting to access response body: #{body}"
       end
     end
   end

--- a/lib/ruby_claim_evidence_api/external_api/response.rb
+++ b/lib/ruby_claim_evidence_api/external_api/response.rb
@@ -81,6 +81,7 @@ module ExternalApi
         if @uses_net_http == true
           body['message']
         else
+          # Possible error response shapes taken from Claim Evidence Swagger
           body['message'] || body['messages'] || body['errors'][0]['message']
         end
       rescue StandardError => e

--- a/lib/ruby_claim_evidence_api/external_api/response.rb
+++ b/lib/ruby_claim_evidence_api/external_api/response.rb
@@ -77,10 +77,15 @@ module ExternalApi
     def error_message
       return 'No error message from ClaimEvidence' if body.nil? || body.empty?
 
-      if @uses_net_http == true
-        body['message']
-      else
-        body['message'] || body['messages'] || body['errors'][0]['message']
+      begin
+        if @uses_net_http == true
+          body['message']
+        else
+          body['message'] || body['messages'] || body['errors'][0]['message']
+        end
+      rescue StandardError => e
+        logger.error "Encountered #{e} while attempting to access response body: #{body}"
+        {}
       end
     end
   end


### PR DESCRIPTION
- Added rescue block to ensure we are always passing a message to our ClaimEvidenceApi error
- Log the error and body shape for non-standard error exceptions