### PR TITLE
Kev Ma/APPEALS-50803

### DIFF
--- a/lib/ruby_claim_evidence_api/external_api/claim_evidence_service.rb
+++ b/lib/ruby_claim_evidence_api/external_api/claim_evidence_service.rb
@@ -4,7 +4,7 @@ require 'pry'
 require 'httpi'
 require 'active_support/all'
 require 'ruby_claim_evidence_api/external_api/response'
-require 'aws-sdk'
+# require 'aws-sdk'
 require 'base64'
 
 module ExternalApi
@@ -26,8 +26,6 @@ module ExternalApi
       "Content-Type": 'application/json',
       "Accept": '*/*'
     }.freeze
-    REGION = ENV['AWS_REGION']
-    AWS_COMPREHEND_SCORE = ENV['AWS_COMPREHEND_SCORE']
 
     FILES_CONTENT_PATH = '/files/:uuid/content'
     FOLDERS_FILES_SEARCH_PATH = '/folders/files:search'
@@ -164,45 +162,49 @@ module ExternalApi
       end
       # rubocop:enable Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/CyclomaticComplexity
 
-      def aws_client
-        @aws_client ||= Aws::Comprehend::Client.new(
-          region: REGION
-        )
-      end
 
-      def aws_stub_client
-        @aws_stub_client ||= Aws::Comprehend::Client.new(
-          region: REGION,
-          stub_responses: true
-        )
-      end
+      # REGION = ENV['AWS_REGION']
+      # AWS_COMPREHEND_SCORE = ENV['AWS_COMPREHEND_SCORE']
 
-      def get_key_phrases(ocr_data, stub_response: false)
-        key_phrase_parameters = {
-          text: ocr_data,
-          language_code: 'en'
-        }
-        if stub_response == true
-          aws_stub_client.detect_key_phrases(key_phrase_parameters).key_phrases
-        else
-          aws_client.detect_key_phrases(key_phrase_parameters).key_phrases
-        end
-      end
+      # def aws_client
+      #   @aws_client ||= Aws::Comprehend::Client.new(
+      #     region: REGION
+      #   )
+      # end
 
-      def filter_key_phrases_by_score(key_phrases)
-        key_phrases.filter_map do |key_phrase|
-          key_phrase[:text] if !key_phrase[:score].nil? && key_phrase[:score] >= AWS_COMPREHEND_SCORE.to_f
-        end
-      end
+      # def aws_stub_client
+      #   @aws_stub_client ||= Aws::Comprehend::Client.new(
+      #     region: REGION,
+      #     stub_responses: true
+      #   )
+      # end
 
-      def get_key_phrases_from_document(doc_uuid, stub_response: false)
-        ocr_data = get_ocr_document(doc_uuid)
+      # def get_key_phrases(ocr_data, stub_response: false)
+      #   key_phrase_parameters = {
+      #     text: ocr_data,
+      #     language_code: 'en'
+      #   }
+      #   if stub_response == true
+      #     aws_stub_client.detect_key_phrases(key_phrase_parameters).key_phrases
+      #   else
+      #     aws_client.detect_key_phrases(key_phrase_parameters).key_phrases
+      #   end
+      # end
 
-        return unless ocr_data.present?
+      # def filter_key_phrases_by_score(key_phrases)
+      #   key_phrases.filter_map do |key_phrase|
+      #     key_phrase[:text] if !key_phrase[:score].nil? && key_phrase[:score] >= AWS_COMPREHEND_SCORE.to_f
+      #   end
+      # end
 
-        key_phrases = get_key_phrases(ocr_data, stub_response: stub_response)
-        filter_key_phrases_by_score(key_phrases)
-      end
+      # def get_key_phrases_from_document(doc_uuid, stub_response: false)
+      #   ocr_data = get_ocr_document(doc_uuid)
+
+      #   return unless ocr_data.present?
+
+      #   key_phrases = get_key_phrases(ocr_data, stub_response: stub_response)
+      #   filter_key_phrases_by_score(key_phrases)
+      # end
 
       private
 

--- a/lib/ruby_claim_evidence_api/fakes/claim_evidence_service.rb
+++ b/lib/ruby_claim_evidence_api/fakes/claim_evidence_service.rb
@@ -3,7 +3,7 @@
 require 'ruby_claim_evidence_api/external_api/response'
 require 'faraday'
 require 'faraday/multipart'
-require 'aws-sdk'
+# require 'aws-sdk'
 module Fakes
   # Mock ClaimEvidenceService. Returns CE API responses when connected to DEV_VPN proxy, and hard-coded responses when not
   class ClaimEvidenceService
@@ -20,12 +20,6 @@ module Fakes
       "Content-Type": 'application/json',
       "Accept": '*/*'
     }.freeze
-    CREDENTIALS = Aws::Credentials.new(
-      ENV['AWS_ACCESS_KEY_ID'],
-      ENV['AWS_SECRET_ACCESS_KEY']
-    )
-    REGION = ENV['AWS_DEFAULT_REGION']
-    AWS_COMPREHEND_SCORE = ENV['AWS_COMPREHEND_SCORE']
 
     class << self
       def document_types_request
@@ -162,44 +156,51 @@ module Fakes
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-      def aws_client
-        @aws_client ||= Aws::Comprehend::Client.new(
-          region: REGION,
-          credentials: CREDENTIALS
-        )
-      end
+      # CREDENTIALS = Aws::Credentials.new(
+      #   ENV['AWS_ACCESS_KEY_ID'],
+      #   ENV['AWS_SECRET_ACCESS_KEY']
+      # )
+      # REGION = ENV['AWS_DEFAULT_REGION']
+      # AWS_COMPREHEND_SCORE = ENV['AWS_COMPREHEND_SCORE']
 
-      def aws_stub_client
-        @aws_stub_client ||= Aws::Comprehend::Client.new(
-          region: REGION,
-          credentials: CREDENTIALS,
-          stub_responses: true
-        )
-      end
+      # def aws_client
+      #   @aws_client ||= Aws::Comprehend::Client.new(
+      #     region: REGION,
+      #     credentials: CREDENTIALS
+      #   )
+      # end
 
-      def get_key_phrases(ocr_data, stub_response: false)
-        key_phrase_parameters = {
-          text: ocr_data,
-          language_code: 'en'
-        }
-        if stub_response == true
-          aws_stub_client.detect_key_phrases(key_phrase_parameters).key_phrases
-        else
-          aws_client.detect_key_phrases(key_phrase_parameters).key_phrases
-        end
-      end
+      # def aws_stub_client
+      #   @aws_stub_client ||= Aws::Comprehend::Client.new(
+      #     region: REGION,
+      #     credentials: CREDENTIALS,
+      #     stub_responses: true
+      #   )
+      # end
 
-      def filter_key_phrases_by_score(key_phrases)
-        key_phrases.filter_map do |key_phrase|
-          key_phrase[:text] if !key_phrase[:score].nil? && key_phrase[:score] >= AWS_COMPREHEND_SCORE
-        end
-      end
+      # def get_key_phrases(ocr_data, stub_response: false)
+      #   key_phrase_parameters = {
+      #     text: ocr_data,
+      #     language_code: 'en'
+      #   }
+      #   if stub_response == true
+      #     aws_stub_client.detect_key_phrases(key_phrase_parameters).key_phrases
+      #   else
+      #     aws_client.detect_key_phrases(key_phrase_parameters).key_phrases
+      #   end
+      # end
 
-      def get_key_phrases_from_document(doc_uuid, stub_response: false)
-        ocr_data = get_ocr_document(doc_uuid)
-        key_phrases = get_key_phrases(ocr_data, stub_response)
-        filter_key_phrases_by_score(key_phrases)
-      end
+      # def filter_key_phrases_by_score(key_phrases)
+      #   key_phrases.filter_map do |key_phrase|
+      #     key_phrase[:text] if !key_phrase[:score].nil? && key_phrase[:score] >= AWS_COMPREHEND_SCORE
+      #   end
+      # end
+
+      # def get_key_phrases_from_document(doc_uuid, stub_response: false)
+      #   ocr_data = get_ocr_document(doc_uuid)
+      #   key_phrases = get_key_phrases(ocr_data, stub_response)
+      #   filter_key_phrases_by_score(key_phrases)
+      # end
 
       private
 

--- a/ruby_claim_evidence_api.gemspec
+++ b/ruby_claim_evidence_api.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
 
   s.add_dependency 'base64'
-  s.add_dependency 'httpi', '3.0.0'
+  s.add_dependency 'httpi'
   s.add_dependency 'rack', '< 3'
 
   s.add_runtime_dependency 'activesupport'

--- a/ruby_claim_evidence_api.gemspec
+++ b/ruby_claim_evidence_api.gemspec
@@ -7,13 +7,15 @@ Gem::Specification.new do |s|
 
   s.authors = 'Caseflow'
   s.email   = 'vacaseflowops@va.gov'
+  s.required_ruby_version = '2.7.3'
 
   # s.add_development_dependency 'aws-sdk', '~> 2.10'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'
 
   s.add_dependency 'base64'
-  s.add_dependency 'httpi'
+  s.add_dependency 'httpi', '3.0.0'
+  s.add_dependency 'rack', '< 3'
 
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'faraday'

--- a/ruby_claim_evidence_api.gemspec
+++ b/ruby_claim_evidence_api.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
 
   s.authors = 'Caseflow'
   s.email   = 'vacaseflowops@va.gov'
-  s.required_ruby_version = '2.7.3'
+  s.required_ruby_version = '~> 2.7'
 
   # s.add_development_dependency 'aws-sdk', '~> 2.10'
   s.add_development_dependency 'pry'

--- a/ruby_claim_evidence_api.gemspec
+++ b/ruby_claim_evidence_api.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.authors = 'Caseflow'
   s.email   = 'vacaseflowops@va.gov'
 
-  s.add_development_dependency 'aws-sdk', '~> 2.10'
+  # s.add_development_dependency 'aws-sdk', '~> 2.10'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'
 

--- a/spec/external_api/claim_evidence_service_spec.rb
+++ b/spec/external_api/claim_evidence_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'httpi'
 require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
-require 'aws-sdk'
+# require 'aws-sdk'
 require './spec/external_api/spec_helper'
 require 'webmock/rspec'
 
@@ -12,10 +12,10 @@ describe ExternalApi::ClaimEvidenceService do
   let(:client_secret) { 'SOME-FAKE-KEY' }
   let(:doc_uuid) { 'SOME-FAKE-UUID' }
   let(:service_id) { 'SOME-FAKE-SERVICE' }
-  let(:aws_access_key_id) { 'dummykeyid' }
-  let(:aws_secret_access_key) { 'dummysecretkey' }
-  let(:aws_region) { 'us-gov-west-1' }
-  let(:aws_credentials) { Aws::Credentials.new(aws_access_key_id, aws_secret_access_key) }
+  # let(:aws_access_key_id) { 'dummykeyid' }
+  # let(:aws_secret_access_key) { 'dummysecretkey' }
+  # let(:aws_region) { 'us-gov-west-1' }
+  # let(:aws_credentials) { Aws::Credentials.new(aws_access_key_id, aws_secret_access_key) }
   let(:file) { '/fake/file' }
   let(:file_number) { '500000000' }
   let(:doc_info) do
@@ -313,84 +313,84 @@ describe ExternalApi::ClaimEvidenceService do
     end
   end
 
-  context 'with Aws Comprehend' do
-    subject { ExternalApi::ClaimEvidenceService }
-    before do
-      subject::REGION ||= aws_region
-      subject::AWS_COMPREHEND_SCORE ||= 0.95
-      stub_request(:put, 'http://169.254.169.254/latest/api/token')
-        .with(
-          headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'User-Agent' => 'aws-sdk-ruby2/2.11.632',
-            'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '21600'
-          }
-        ).to_return(status: 200, body: '', headers: {})
+  # context 'with Aws Comprehend' do
+  #   subject { ExternalApi::ClaimEvidenceService }
+  #   before do
+  #     subject::REGION ||= aws_region
+  #     subject::AWS_COMPREHEND_SCORE ||= 0.95
+  #     stub_request(:put, 'http://169.254.169.254/latest/api/token')
+  #       .with(
+  #         headers: {
+  #           'Accept' => '*/*',
+  #           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+  #           'User-Agent' => 'aws-sdk-ruby2/2.11.632',
+  #           'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '21600'
+  #         }
+  #       ).to_return(status: 200, body: '', headers: {})
 
-      stub_request(:get, 'http://169.254.169.254/latest/meta-data/iam/security-credentials/')
-        .with(
-          headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'User-Agent' => 'aws-sdk-ruby2/2.11.632'
-          }
-        ).to_return(status: 200, body: '', headers: {})
-    end
-    let(:ocr_data) { 'Some text string' }
-    let(:stub_response) do
-      [
-        {
-          score: 0.9825336337089539,
-          text: 'Department',
-          begin_offset: 1,
-          end_offset: 11
-        },
-        {
-          score: 0.9376260447502136,
-          text: "Veterans Affairs\nCERTIFICATION",
-          begin_offset: 15,
-          end_offset: 45
-        },
-        {
-          score: 0.994326651096344,
-          text: "APPEAL\n1A",
-          begin_offset: 49,
-          end_offset: 58
-        }
-      ]
-    end
+  #     stub_request(:get, 'http://169.254.169.254/latest/meta-data/iam/security-credentials/')
+  #       .with(
+  #         headers: {
+  #           'Accept' => '*/*',
+  #           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+  #           'User-Agent' => 'aws-sdk-ruby2/2.11.632'
+  #         }
+  #       ).to_return(status: 200, body: '', headers: {})
+  #   end
+  #   let(:ocr_data) { 'Some text string' }
+  #   let(:stub_response) do
+  #     [
+  #       {
+  #         score: 0.9825336337089539,
+  #         text: 'Department',
+  #         begin_offset: 1,
+  #         end_offset: 11
+  #       },
+  #       {
+  #         score: 0.9376260447502136,
+  #         text: "Veterans Affairs\nCERTIFICATION",
+  #         begin_offset: 15,
+  #         end_offset: 45
+  #       },
+  #       {
+  #         score: 0.994326651096344,
+  #         text: "APPEAL\n1A",
+  #         begin_offset: 49,
+  #         end_offset: 58
+  #       }
+  #     ]
+  #   end
 
-    it 'initializes Aws Comprehend client with region' do
-      expect(subject::REGION).not_to be_nil
-      expect(subject.aws_client).not_to be_nil
-      expect(subject.aws_stub_client).not_to be_nil
-    end
+  #   it 'initializes Aws Comprehend client with region' do
+  #     expect(subject::REGION).not_to be_nil
+  #     expect(subject.aws_client).not_to be_nil
+  #     expect(subject.aws_stub_client).not_to be_nil
+  #   end
 
-    it 'performs #detect_key_phrase real-time analysis on ocr_data' do
-      subject.aws_stub_client.stub_responses(:detect_key_phrases, { key_phrases: stub_response })
-      # Stubbed data returns an Aws struct - Map the data to a hash compare
-      formatted_output = subject.get_key_phrases(ocr_data, stub_response: true).map do |struct|
-        {
-          score: struct.score,
-          text: struct.text,
-          begin_offset: struct.begin_offset,
-          end_offset: struct.end_offset
-        }
-      end
-      expect(formatted_output).to eq(stub_response)
-    end
+  #   it 'performs #detect_key_phrase real-time analysis on ocr_data' do
+  #     subject.aws_stub_client.stub_responses(:detect_key_phrases, { key_phrases: stub_response })
+  #     # Stubbed data returns an Aws struct - Map the data to a hash compare
+  #     formatted_output = subject.get_key_phrases(ocr_data, stub_response: true).map do |struct|
+  #       {
+  #         score: struct.score,
+  #         text: struct.text,
+  #         begin_offset: struct.begin_offset,
+  #         end_offset: struct.end_offset
+  #       }
+  #     end
+  #     expect(formatted_output).to eq(stub_response)
+  #   end
 
-    it 'filters key_phrases by score >= AWS_COMPREHEND_SCORE' do
-      expect(subject.filter_key_phrases_by_score(stub_response)).to eq(%W[Department APPEAL\n1A])
-    end
+  #   it 'filters key_phrases by score >= AWS_COMPREHEND_SCORE' do
+  #     expect(subject.filter_key_phrases_by_score(stub_response)).to eq(%W[Department APPEAL\n1A])
+  #   end
 
-    it 'retrieves key_phrases from CE API document' do
-      subject.aws_stub_client.stub_responses(:detect_key_phrases, { key_phrases: stub_response })
-      allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
-      allow(HTTPI).to receive(:get).and_return(success_get_raw_ocr_document_response)
-      output = subject.get_key_phrases_from_document(doc_uuid, stub_response: true)
-      expect(output).to eq(%W[Department APPEAL\n1A])
-    end
-  end
+  #   it 'retrieves key_phrases from CE API document' do
+  #     subject.aws_stub_client.stub_responses(:detect_key_phrases, { key_phrases: stub_response })
+  #     allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
+  #     allow(HTTPI).to receive(:get).and_return(success_get_raw_ocr_document_response)
+  #     output = subject.get_key_phrases_from_document(doc_uuid, stub_response: true)
+  #     expect(output).to eq(%W[Department APPEAL\n1A])
+  #   end
+  # end
 end


### PR DESCRIPTION
- Reverted AWS Comprehend methods and tests from claim_evidence_service.rb (ExternalApi:: and Fakes::) and claim_evidence_service_spec.rb
- Updated gemfile for the following:
  1. Specified ruby version to '~> 2.7.3' to match Caseflow and Efolder
  2. Added specific rack and HTTPI dependencies due to breaking updates to both libraries
  3. Removed aws-sdk
