### PR TITLE
Add New Endpoint for Updating Veteran Documents

### DIFF
--- a/lib/ruby_claim_evidence_api/api_base.rb
+++ b/lib/ruby_claim_evidence_api/api_base.rb
@@ -25,4 +25,12 @@ class ApiBase
 
     @api_client
   end
+
+  def x_folder_uri_header(veteran_file_number)
+    {
+      "Content-Type": 'application/json',
+      "Accept": '*/*',
+      "X-Folder-URI": "VETERAN:FILENUMBER:#{veteran_file_number}"
+    }
+  end
 end

--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_fetcher.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_fetcher.rb
@@ -35,7 +35,7 @@ module ExternalApi
     private
 
     def fetch_paginated_documents(veteran_file_number:, filters: {})
-      initial_search = file_folders_search(veteran_file_number: veteran_file_number, body: file_folders_search_body(filters: filters))
+      initial_search = post_file_folders_search(veteran_file_number: veteran_file_number, body: file_folders_search_body(filters: filters))
       initial_results = initial_search.body
 
       total_result = initial_results['page']['totalResults'].to_i
@@ -48,7 +48,7 @@ module ExternalApi
       build_fetch_veteran_file_list_response(responses, initial_results, initial_search)
     end
 
-    def file_folders_search(veteran_file_number:, query: {}, body: nil)
+    def post_file_folders_search(veteran_file_number:, query: {}, body: nil)
       api_client.send_ce_api_request(
         endpoint: '/folders/files:search',
         query: query,
@@ -64,7 +64,7 @@ module ExternalApi
       until current_page == total_pages
         current_page += 1
 
-        current_search = file_folders_search(
+        current_search = post_file_folders_search(
           veteran_file_number: veteran_file_number,
           body: file_folders_search_body(page: current_page)
         )
@@ -100,14 +100,6 @@ module ExternalApi
           "page": page
         },
         "filters": filters
-      }
-    end
-
-    def x_folder_uri_header(veteran_file_number)
-      {
-        "Content-Type": 'application/json',
-        "Accept": '*/*',
-        "X-Folder-URI": "VETERAN:FILENUMBER:#{veteran_file_number}"
       }
     end
 

--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
@@ -9,7 +9,7 @@ module ExternalApi
       post_files_uuid(
         veteran_file_number: veteran_file_number,
         file_uuid: file_uuid,
-        body: post_files_uuid_body(file_update_payload)
+        body: update_veteran_file_body(file_update_payload)
       )
     end
 
@@ -25,7 +25,7 @@ module ExternalApi
       )
     end
 
-    def post_files_uuid_body(file_update_payload)
+    def update_veteran_file_body(file_update_payload)
       {
         payload: {
           providerData: {

--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'ruby_claim_evidence_api/api_base'
+
+module ExternalApi
+  # Updates documents in the CE API documents for a given veteran
+  class VeteranFileUpdater < ApiBase
+    def update_veteran_file(veteran_file_number:, file_uuid:, file_update_request:)
+      post_files_uuid(
+        veteran_file_number: veteran_file_number,
+        file_uuid: file_uuid,
+        body: post_files_uuid_body(file_update_request)
+      )
+    end
+
+    private
+
+    def post_files_uuid(veteran_file_number:, file_uuid:, query: {}, body: nil)
+      api_client.send_ce_api_request(
+        endpoint: "/files/#{file_uuid}",
+        query: query,
+        headers: x_folder_uri_header(veteran_file_number),
+        method: :post,
+        body: body
+      )
+    end
+
+    def post_files_uuid_body(file_update_request)
+      {
+        payload: {
+          providerData: {
+            contentSource: file_update_request.file_content_source,
+            documentTypeId: file_update_request.document_type_id,
+            dateVaReceivedDocument: file_update_request.date_va_received_document
+          }
+        },
+        file: file_update_request.file_content
+      }
+    end
+  end
+end

--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
@@ -5,11 +5,11 @@ require 'ruby_claim_evidence_api/api_base'
 module ExternalApi
   # Updates documents in the CE API documents for a given veteran
   class VeteranFileUpdater < ApiBase
-    def update_veteran_file(veteran_file_number:, file_uuid:, file_update_request:)
+    def update_veteran_file(veteran_file_number:, file_uuid:, file_update_payload:)
       post_files_uuid(
         veteran_file_number: veteran_file_number,
         file_uuid: file_uuid,
-        body: post_files_uuid_body(file_update_request)
+        body: post_files_uuid_body(file_update_payload)
       )
     end
 
@@ -25,16 +25,16 @@ module ExternalApi
       )
     end
 
-    def post_files_uuid_body(file_update_request)
+    def post_files_uuid_body(file_update_payload)
       {
         payload: {
           providerData: {
-            contentSource: file_update_request.file_content_source,
-            documentTypeId: file_update_request.document_type_id,
-            dateVaReceivedDocument: file_update_request.date_va_received_document
+            contentSource: file_update_payload.file_content_source,
+            documentTypeId: file_update_payload.document_type_id,
+            dateVaReceivedDocument: file_update_payload.date_va_received_document
           }
         },
-        file: file_update_request.file_content
+        file: file_update_payload.file_content
       }
     end
   end

--- a/lib/ruby_claim_evidence_api/fakes/mock_api_client.rb
+++ b/lib/ruby_claim_evidence_api/fakes/mock_api_client.rb
@@ -18,8 +18,10 @@ class MockApiClient
     endpoint = args[0][:endpoint]
 
     case endpoint
-    when %r{/files/[\w\d-]+/content}
+    when %r{\/files\/[\w\d-]+\/content}
       files_content_response
+    when %r{\/files\/[\w\d-]+}
+      update_veteran_file_response
     when ExternalApi::ClaimEvidenceService::FOLDERS_FILES_SEARCH_PATH
       files_folders_search_response
     else
@@ -42,6 +44,17 @@ class MockApiClient
       File.join(
         Gem::Specification.find_by_name('ruby_claim_evidence_api').gem_dir,
         'spec/support/api_responses/file_folders_search_single_page.json'
+      )
+    )
+
+    ExternalApi::Response.new(HTTPI::Response.new(200, {}, json_obj))
+  end
+
+  def update_veteran_file_response
+    json_obj = File.read(
+      File.join(
+        Gem::Specification.find_by_name('ruby_claim_evidence_api').gem_dir,
+        'spec/support/api_responses/update_veteran_file_response.json'
       )
     )
 

--- a/lib/ruby_claim_evidence_api/fakes/mock_api_client.rb
+++ b/lib/ruby_claim_evidence_api/fakes/mock_api_client.rb
@@ -6,27 +6,25 @@ require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 
 # Mocks API responses keyed off of API URI paths
 class MockApiClient
-  def respond_to_missing?(_method_name, _include_private = false); end
-
-  def method_missing(_method, *args, &_block)
-    mock_api_response(*args)
+  def send_ce_api_request(*args)
+    mock_api_response(args[0][:endpoint])
   end
 
   private
 
-  def mock_api_response(*args)
-    endpoint = args[0][:endpoint]
+  def mock_api_response(endpoint)
+    response = not_found_response
 
     case endpoint
-    when %r{\/files\/[\w\d-]+\/content}
-      files_content_response
-    when %r{\/files\/[\w\d-]+}
-      update_veteran_file_response
+    when /\/files\/[\w\d-]+\/content/
+      response = files_content_response
+    when /\/files\/[\w\d-]+/
+      response = update_veteran_file_response
     when ExternalApi::ClaimEvidenceService::FOLDERS_FILES_SEARCH_PATH
-      files_folders_search_response
-    else
-      not_found_response
+      response = files_folders_search_response
     end
+
+    response
   end
 
   def files_content_response
@@ -34,9 +32,8 @@ class MockApiClient
       Gem::Specification.find_by_name('ruby_claim_evidence_api').gem_dir,
       'spec/support/get_document_content.pdf'
     )
-    ExternalApi::Response.new(
-      HTTPI::Response.new(200, {}, File.binread(file_name))
-    )
+
+    ExternalApi::Response.new(HTTPI::Response.new(200, {}, File.binread(file_name)))
   end
 
   def files_folders_search_response

--- a/lib/ruby_claim_evidence_api/models/file_update_payload.rb
+++ b/lib/ruby_claim_evidence_api/models/file_update_payload.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Encapsulates all of the data required to perform a file update in the CE API
-class FileUpdateRequest
+class FileUpdatePayload
   attr_accessor :date_va_received_document,
                 :document_type_id,
                 :file_content,

--- a/lib/ruby_claim_evidence_api/models/file_update_request.rb
+++ b/lib/ruby_claim_evidence_api/models/file_update_request.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Encapsulates all of the data required to perform a file update in the CE API
+class FileUpdateRequest
+  attr_accessor :date_va_received_document,
+                :document_type_id,
+                :file_content,
+                :file_content_source
+
+  def initialize(params = {})
+    self.date_va_received_document = params[:date_va_received_document] || ''
+    self.document_type_id = params[:document_type_id] || ''
+    self.file_content = params[:file_content] || ''
+    self.file_content_source = params[:file_content_source] || ''
+  end
+end

--- a/spec/external_api/veteran_file_fetcher_spec.rb
+++ b/spec/external_api/veteran_file_fetcher_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'ruby_claim_evidence_api/api_base'
+require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
+require 'ruby_claim_evidence_api/external_api/response'
+require 'ruby_claim_evidence_api/external_api/veteran_file_fetcher'
+require './spec/external_api/spec_helper'
+
+describe ExternalApi::VeteranFileFetcher do
+  subject(:described) { described_class.new(use_canned_api_responses: false) }
+
+  let(:mock_api_response) do
+    instance_double(
+      ExternalApi::Response,
+      body: { page: { totalResults: 0, totalPages: 1, currentPage: 1 } }.with_indifferent_access
+    )
+  end
+
+  describe '#fetch_veteran_file_list' do
+    it 'calls the API endpoint' do
+      expect(ExternalApi::ClaimEvidenceService).to receive(:send_ce_api_request)
+        .with(
+          endpoint: '/folders/files:search',
+          query: {},
+          headers: {
+            "Content-Type": 'application/json',
+            "Accept": '*/*',
+            "X-Folder-URI": 'VETERAN:FILENUMBER:123456789'
+          },
+          method: :post,
+          body: {
+            "pageRequest": {
+              "resultsPerPage": 20,
+              "page": 1
+            },
+            "filters": {}
+          }
+        ).and_return(mock_api_response)
+
+      described.fetch_veteran_file_list(veteran_file_number: '123456789')
+    end
+  end
+end

--- a/spec/external_api/veteran_file_updater_spec.rb
+++ b/spec/external_api/veteran_file_updater_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'ruby_claim_evidence_api/api_base'
+require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
+require 'ruby_claim_evidence_api/external_api/response'
+require 'ruby_claim_evidence_api/external_api/veteran_file_updater'
+require 'ruby_claim_evidence_api/models/file_update_request'
+require './spec/external_api/spec_helper'
+
+describe ExternalApi::VeteranFileUpdater do
+  subject(:described) { described_class.new(use_canned_api_responses: false) }
+
+  let(:mock_api_response) { instance_double(ExternalApi::Response) }
+
+  describe '#update_veteran_file' do
+    it 'calls the API endpoint' do
+      expect(ExternalApi::ClaimEvidenceService).to receive(:send_ce_api_request)
+        .with(
+          endpoint: '/files/0003E65D-0000-C118-A964-CA1AEC2925E6',
+          query: {},
+          headers: {
+            "Content-Type": 'application/json',
+            "Accept": '*/*',
+            "X-Folder-URI": 'VETERAN:FILENUMBER:123456789'
+          },
+          method: :post,
+          body:{
+            payload: {
+              providerData: {
+                contentSource: '',
+                documentTypeId: '',
+                dateVaReceivedDocument: ''
+              }
+            },
+            file: ''
+          }
+        ).and_return(mock_api_response)
+
+      file_update_request = FileUpdateRequest.new
+
+      described.update_veteran_file(
+        veteran_file_number: '123456789',
+        file_uuid: '0003E65D-0000-C118-A964-CA1AEC2925E6',
+        file_update_request: file_update_request
+      )
+    end
+  end
+end

--- a/spec/external_api/veteran_file_updater_spec.rb
+++ b/spec/external_api/veteran_file_updater_spec.rb
@@ -4,7 +4,7 @@ require 'ruby_claim_evidence_api/api_base'
 require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/external_api/response'
 require 'ruby_claim_evidence_api/external_api/veteran_file_updater'
-require 'ruby_claim_evidence_api/models/file_update_request'
+require 'ruby_claim_evidence_api/models/file_update_payload'
 require './spec/external_api/spec_helper'
 
 describe ExternalApi::VeteranFileUpdater do
@@ -36,12 +36,12 @@ describe ExternalApi::VeteranFileUpdater do
           }
         ).and_return(mock_api_response)
 
-      file_update_request = FileUpdateRequest.new
+      file_update_payload = FileUpdatePayload.new
 
       described.update_veteran_file(
         veteran_file_number: '123456789',
         file_uuid: '0003E65D-0000-C118-A964-CA1AEC2925E6',
-        file_update_request: file_update_request
+        file_update_payload: file_update_payload
       )
     end
   end

--- a/spec/fakes/mock_api_client_spec.rb
+++ b/spec/fakes/mock_api_client_spec.rb
@@ -16,6 +16,15 @@ describe MockApiClient do
       expect(response.resp.body.encoding).to eq(Encoding::ASCII_8BIT)
     end
 
+    it 'successfully calls the update veteran file path' do
+      response = described.send_ce_api_request(endpoint: '/files/0003E65D-0000-C118-A964-CA1AEC2925E6')
+
+      expect(response).to be_a ExternalApi::Response
+      expect(response.code).to eq 200
+      expect(response.body).to have_key('conversionInformation')
+      expect(response.body).to have_key('currentVersionUuid')
+    end
+
     it 'successfully calls the folders files search path' do
       response = described.send_ce_api_request(endpoint: '/folders/files:search')
 

--- a/spec/support/api_responses/update_veteran_file_response.json
+++ b/spec/support/api_responses/update_veteran_file_response.json
@@ -1,0 +1,16 @@
+{
+  "currentVersionUuid": "a30626c9-954d-4dd1-9f70-1e38756d9d98",
+  "conversionInformation": {
+    "preprocessed": {
+      "versionUuid": "046b6c7f-0b8a-43b9-b35d-6489e6daee92",
+      "uploadedDateTime": "2019-03-28T22:48:53",
+      "mimeType": "application/pdf"
+    },
+    "converted": {
+      "versionUuid": "046b6c7f-0b8a-43b9-b35d-6489e6daee92",
+      "uploadedDateTime": "2019-03-28T22:48:53",
+      "mimeType": "application/pdf"
+    }
+  },
+  "uuid": "a30626c9-954d-4dd1-9f70-1e38756d9d97"
+}


### PR DESCRIPTION
- Add new class for posting veteran document updates to the Claim Evidence API.
- Add supporting files and specs throughout.