### PR TITLE
Use Multi-Part Form To Post Doc Updates

### DIFF
--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
@@ -6,36 +6,11 @@ module ExternalApi
   # Updates documents in the CE API documents for a given veteran
   class VeteranFileUpdater < ApiBase
     def update_veteran_file(veteran_file_number:, file_uuid:, file_update_payload:)
-      post_files_uuid(
+      api_client.update_document(
         veteran_file_number: veteran_file_number,
         file_uuid: file_uuid,
-        body: update_veteran_file_body(file_update_payload)
+        file_update_payload: file_update_payload
       )
-    end
-
-    private
-
-    def post_files_uuid(veteran_file_number:, file_uuid:, query: {}, body: nil)
-      api_client.send_ce_api_request(
-        endpoint: "/files/#{file_uuid}",
-        query: query,
-        headers: x_folder_uri_header(veteran_file_number),
-        method: :post,
-        body: body
-      )
-    end
-
-    def update_veteran_file_body(file_update_payload)
-      {
-        payload: {
-          providerData: {
-            contentSource: file_update_payload.file_content_source,
-            documentTypeId: file_update_payload.document_type_id,
-            dateVaReceivedDocument: file_update_payload.date_va_received_document
-          }
-        },
-        file: file_update_payload.file_content
-      }
     end
   end
 end

--- a/lib/ruby_claim_evidence_api/models/claim_evidence_file_update_payload.rb
+++ b/lib/ruby_claim_evidence_api/models/claim_evidence_file_update_payload.rb
@@ -4,13 +4,13 @@
 class ClaimEvidenceFileUpdatePayload
   attr_accessor :date_va_received_document,
                 :document_type_id,
-                :file_content,
+                :file_content_path,
                 :file_content_source
 
   def initialize(params = {})
     self.date_va_received_document = params[:date_va_received_document] || ''
     self.document_type_id = params[:document_type_id] || ''
-    self.file_content = params[:file_content] || ''
+    self.file_content_path = params[:file_content_path] || ''
     self.file_content_source = params[:file_content_source] || ''
   end
 end

--- a/spec/external_api/claim_evidence_service_spec.rb
+++ b/spec/external_api/claim_evidence_service_spec.rb
@@ -2,6 +2,7 @@
 
 require 'httpi'
 require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
+require 'ruby_claim_evidence_api/models/claim_evidence_file_update_payload'
 # require 'aws-sdk'
 require './spec/external_api/spec_helper'
 require 'webmock/rspec'
@@ -253,7 +254,7 @@ describe ExternalApi::ClaimEvidenceService do
             headers: {
               'Accept' => '*/*',
               'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'Authorization' => 'fake.jwt.token',
+              'Authorization' => 'Bearer fake.jwt.token',
               'Content-Type' => 'multipart/form-data',
               'Host' => 'fake.api.claimevidence.comapi',
               'User-Agent' => 'Ruby',
@@ -264,6 +265,20 @@ describe ExternalApi::ClaimEvidenceService do
 
       it 'uploads document' do
         ExternalApi::ClaimEvidenceService.upload_document(file, file_number, doc_info)
+        expect(WebMock).to have_requested(:post, url)
+      end
+
+      it 'updates document' do
+        ExternalApi::ClaimEvidenceService.update_document(
+          veteran_file_number: file_number,
+          file_uuid: "123456789",
+          file_update_payload: ClaimEvidenceFileUpdatePayload.new(
+            date_va_received_document: Time.zone.now,
+            document_type_id: uploadable_document.document_type_id,
+            file_content_path: uploadable_document.pdf_location,
+            file_content_source: uploadable_document.source
+          )
+        )
         expect(WebMock).to have_requested(:post, url)
       end
     end

--- a/spec/external_api/veteran_file_updater_spec.rb
+++ b/spec/external_api/veteran_file_updater_spec.rb
@@ -4,7 +4,7 @@ require 'ruby_claim_evidence_api/api_base'
 require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/external_api/response'
 require 'ruby_claim_evidence_api/external_api/veteran_file_updater'
-require 'ruby_claim_evidence_api/models/file_update_payload'
+require 'ruby_claim_evidence_api/models/claim_evidence_file_update_payload'
 require './spec/external_api/spec_helper'
 
 describe ExternalApi::VeteranFileUpdater do
@@ -14,34 +14,17 @@ describe ExternalApi::VeteranFileUpdater do
 
   describe '#update_veteran_file' do
     it 'calls the API endpoint' do
-      expect(ExternalApi::ClaimEvidenceService).to receive(:send_ce_api_request)
+      expect(ExternalApi::ClaimEvidenceService).to receive(:update_document)
         .with(
-          endpoint: '/files/0003E65D-0000-C118-A964-CA1AEC2925E6',
-          query: {},
-          headers: {
-            "Content-Type": 'application/json',
-            "Accept": '*/*',
-            "X-Folder-URI": 'VETERAN:FILENUMBER:123456789'
-          },
-          method: :post,
-          body:{
-            payload: {
-              providerData: {
-                contentSource: '',
-                documentTypeId: '',
-                dateVaReceivedDocument: ''
-              }
-            },
-            file: ''
-          }
+          veteran_file_number: '123456789',
+          file_uuid: '0003E65D-0000-C118-A964-CA1AEC2925E6',
+          file_update_payload: instance_of(ClaimEvidenceFileUpdatePayload)
         ).and_return(mock_api_response)
-
-      file_update_payload = ClaimEvidenceFileUpdatePayload.new
 
       described.update_veteran_file(
         veteran_file_number: '123456789',
         file_uuid: '0003E65D-0000-C118-A964-CA1AEC2925E6',
-        file_update_payload: file_update_payload
+        file_update_payload: ClaimEvidenceFileUpdatePayload.new
       )
     end
   end


### PR DESCRIPTION
- Update VeteranFileUpdater to send requests using multi-part form data.
- Update specs.