### PR TITLE
Add Missing Arg to File Fetcher and Mock Responder

### DIFF
--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_fetcher.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_fetcher.rb
@@ -44,11 +44,11 @@ module ExternalApi
       initial_search = post_file_folders_search(veteran_file_number: veteran_file_number, body: file_folders_search_body(filters: filters))
       initial_results = initial_search.body
 
-      total_result = initial_results['page']['totalResults'].to_i
+      total_results = initial_results['page']['totalResults'].to_i
       total_pages = initial_results['page']['totalPages'].to_i
       current_page = initial_results['page']['currentPage'].to_i
 
-      return initial_search if total_result.zero? || current_page == total_pages
+      return initial_search if total_results.zero? || current_page == total_pages
 
       responses = fetch_remaining_pages(initial_search, current_page, total_pages, veteran_file_number)
       build_fetch_veteran_file_list_response(responses, initial_results, initial_search)
@@ -95,7 +95,8 @@ module ExternalApi
       final_response = { 'page': initial_results['page'], 'files': response_files }.to_json
 
       ExternalApi::Response.new(
-        HTTPI::Response.new(initial_search.code, initial_search.resp.headers, final_response)
+        HTTPI::Response.new(initial_search.code, initial_search.resp.headers, final_response),
+        nil
       )
     end
 

--- a/lib/ruby_claim_evidence_api/fakes/mock_api_client.rb
+++ b/lib/ruby_claim_evidence_api/fakes/mock_api_client.rb
@@ -13,20 +13,18 @@ class MockApiClient
   private
 
   def mock_api_response(endpoint)
-    response = not_found_response
-
     case endpoint
-    when /\/files\/[\w\d-]+\/content/
-      response = files_content_response
-    when /\/files\/[\w\d-]+/
-      response = update_veteran_file_response
-    when /\/files/
-      response = upload_veteran_file_response
+    when %r{^/files/[\w\d-]+/content}
+      files_content_response
+    when %r{^/files/[\w\d-]+}
+      update_veteran_file_response
+    when %r{^/files}
+      upload_veteran_file_response
     when ExternalApi::ClaimEvidenceService::FOLDERS_FILES_SEARCH_PATH
-      response = files_folders_search_response
+      files_folders_search_response
+    else
+      not_found_response
     end
-
-    response
   end
 
   def files_content_response
@@ -35,7 +33,10 @@ class MockApiClient
       'spec/support/get_document_content.pdf'
     )
 
-    ExternalApi::Response.new(HTTPI::Response.new(200, {}, File.binread(file_name)))
+    ExternalApi::Response.new(
+      HTTPI::Response.new(200, {}, File.binread(file_name)),
+      :files_content_response
+    )
   end
 
   def files_folders_search_response
@@ -46,7 +47,10 @@ class MockApiClient
       )
     )
 
-    ExternalApi::Response.new(HTTPI::Response.new(200, {}, json_obj))
+    ExternalApi::Response.new(
+      HTTPI::Response.new(200, {}, json_obj),
+      :files_folders_search_response
+    )
   end
 
   def update_veteran_file_response
@@ -57,7 +61,10 @@ class MockApiClient
       )
     )
 
-    ExternalApi::Response.new(HTTPI::Response.new(200, {}, json_obj))
+    ExternalApi::Response.new(
+      HTTPI::Response.new(200, {}, json_obj),
+      :update_veteran_file_response
+    )
   end
 
   def upload_veteran_file_response
@@ -68,12 +75,16 @@ class MockApiClient
         'spec/support/api_responses/update_veteran_file_response.json'
       )
     )
-    ExternalApi::Response.new(HTTPI::Response.new(200, {}, json_obj))
+    ExternalApi::Response.new(
+      HTTPI::Response.new(200, {}, json_obj),
+      :upload_veteran_file_response
+    )
   end
 
   def not_found_response
     ExternalApi::Response.new(
-      HTTPI::Response.new(404, {}, { status: 'not found' })
+      HTTPI::Response.new(404, {}, { status: 'not found' }),
+      :not_found_response
     )
   end
 end


### PR DESCRIPTION
Previous commit improved logging by adding the request to the response; however, a few more places needed the request or nil in order to avoide an argument error.