### PR TITLE
Update unused paramter to have a default nil

### DIFF
--- a/lib/ruby_claim_evidence_api/external_api/response.rb
+++ b/lib/ruby_claim_evidence_api/external_api/response.rb
@@ -40,7 +40,7 @@ module ExternalApi
       end
     end
 
-    def to_json(_)
+    def to_json(_ = nil)
       {
         error: error_message,
         body: body


### PR DESCRIPTION
ArgumentError was coming from `def to_json(_)`. Update the unused parameter to include a nil default value