### PR TITLE
Update ClaimEvidenceService to Use Instance Methods

### DIFF
--- a/lib/ruby_claim_evidence_api/api_base.rb
+++ b/lib/ruby_claim_evidence_api/api_base.rb
@@ -15,15 +15,11 @@ class ApiBase
   attr_accessor :use_canned_api_responses, :logger
 
   def api_client
-    return @api_client unless @api_client.nil?
-
-    @api_client = if use_canned_api_responses
-                    MockApiClient.new
-                  else
-                    ExternalApi::ClaimEvidenceService.new
-                  end
-
-    @api_client
+    if use_canned_api_responses
+      MockApiClient.new
+    else
+      ExternalApi::ClaimEvidenceService.new
+    end
   end
 
   def x_folder_uri_header(veteran_file_number)

--- a/lib/ruby_claim_evidence_api/api_base.rb
+++ b/lib/ruby_claim_evidence_api/api_base.rb
@@ -20,7 +20,7 @@ class ApiBase
     @api_client = if use_canned_api_responses
                     MockApiClient.new
                   else
-                    ExternalApi::ClaimEvidenceService
+                    ExternalApi::ClaimEvidenceService.new
                   end
 
     @api_client

--- a/lib/ruby_claim_evidence_api/claim_evidence.rb
+++ b/lib/ruby_claim_evidence_api/claim_evidence.rb
@@ -1,1 +1,0 @@
-ClaimEvidenceService = (!ApplicationController.dependencies_faked? ? ExternalApi::ClaimEvidenceService : Fakes::ClaimEvidenceService)

--- a/lib/ruby_claim_evidence_api/models/claim_evidence_request.rb
+++ b/lib/ruby_claim_evidence_api/models/claim_evidence_request.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Encapsulates all of the data required to perform a file upload in the CE API
+class ClaimEvidenceRequest
+  attr_accessor :user_css_id,
+                :station_id
+
+  def initialize(params = {})
+    self.user_css_id = params[:user_css_id] || ''
+    self.station_id = params[:station_id] || ''
+  end
+end

--- a/spec/api_base_spec.rb
+++ b/spec/api_base_spec.rb
@@ -16,7 +16,7 @@ describe ApiBase do
     let(:described) { described_class.new(use_canned_api_responses: false) }
 
     it 'uses the actual API client' do
-      expect(described.send(:api_client).new).to be_a ExternalApi::ClaimEvidenceService
+      expect(described.send(:api_client)).to be_an_instance_of ExternalApi::ClaimEvidenceService
     end
   end
 end

--- a/spec/external_api/claim_evidence_service_spec.rb
+++ b/spec/external_api/claim_evidence_service_spec.rb
@@ -9,7 +9,6 @@ require 'webmock/rspec'
 
 describe ExternalApi::ClaimEvidenceService do
   # Fake/Testing ENV variables
-  let(:base_url) { 'https://fake.api.claimevidence.com' }
   let(:client_secret) { 'SOME-FAKE-KEY' }
   let(:doc_uuid) { 'SOME-FAKE-UUID' }
   let(:service_id) { 'SOME-FAKE-SERVICE' }
@@ -33,8 +32,20 @@ describe ExternalApi::ClaimEvidenceService do
       }
     }
   end
+
   before do
-    ExternalApi::ClaimEvidenceService::BASE_URL = base_url
+    ENV['CLAIM_EVIDENCE_SECRET'] = 'CLAIM_EVIDENCE_SECRET'
+    ENV['CLAIM_EVIDENCE_ISSUER'] = 'CLAIM_EVIDENCE_ISSUER'
+    ENV['CLAIM_EVIDENCE_VBMS_USER'] = 'CLAIM_EVIDENCE_VBMS_USER'
+    ENV['CLAIM_EVIDENCE_STATION_ID'] = 'CLAIM_EVIDENCE_STATION_ID'
+    ENV['CLAIM_EVIDENCE_API_URL'] = 'https://fake.api.claimevidence.com/'
+    ENV['SSL_CERT_FILE'] = 'SSL_CERT_FILE'
+    ENV['BGS_CERT_LOCATION'] = 'BGS_CERT_LOCATION'
+    ENV['BGS_KEY_LOCATION'] = 'BGS_KEY_LOCATION'
+
+    allow(File).to receive(:read).and_call_original
+    allow(File).to receive(:read).with('BGS_CERT_LOCATION').and_return('BGS_CERT_LOCATION')
+    allow(File).to receive(:read).with('BGS_KEY_LOCATION').and_return('BGS_KEY_LOCATION')
   end
 
   let(:doc_types_body) do
@@ -210,53 +221,53 @@ describe ExternalApi::ClaimEvidenceService do
 
   context 'response success' do
     it 'document types' do
-      allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
       allow(HTTPI).to receive(:get).and_return(success_doc_types_response)
-      document_types = ExternalApi::ClaimEvidenceService.document_types
+      document_types = described_class.new.document_types
       expect(document_types).to be_present
     end
 
     it 'alt_document_types' do
-      allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
       allow(HTTPI).to receive(:get).and_return(success_alt_doc_types_response)
-      alt_document_types = ExternalApi::ClaimEvidenceService.alt_document_types
+      alt_document_types = described_class.new.alt_document_types
       expect(alt_document_types).to be_present
     end
 
     it 'get_ocr_document' do
-      allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
       allow(HTTPI).to receive(:get).and_return(success_get_raw_ocr_document_response)
-      get_ocr_document = ExternalApi::ClaimEvidenceService.get_ocr_document(doc_uuid)
+      get_ocr_document = described_class.new.get_ocr_document(doc_uuid)
       expect(get_ocr_document).to be_present
       expect(get_ocr_document).to eq('Lorem ipsum')
     end
 
     describe 'with multipart Net HTTP request' do
-      let(:url) { 'https://fake.api.claimevidence.comapi/v1/rest/files' }
-      let(:ssl_key_path) { 'path/to/key' }
-      let(:ssl_cert_path) { 'path/to/cert' }
+      let(:upload_url) { 'https://fake.api.claimevidence.com/api/v1/rest/files' }
+      let(:update_url) { 'https://fake.api.claimevidence.com/api/v1/rest/files/123456789' }
 
       before do
-        allow(ENV).to receive(:[]).with('BGS_CERT_LOCATION').and_return(ssl_cert_path)
-        allow(ENV).to receive(:[]).with('BGS_KEY_LOCATION').and_return(ssl_key_path)
-
         allow(File).to receive(:binread).and_return("\x05\x00\x68\x65\x6c\x6c\x6f")
-        allow(File).to receive(:read).with(ssl_cert_path).and_return('mock cert content')
-        allow(File).to receive(:read).with(ssl_key_path).and_return('mock key content')
 
-        allow(OpenSSL::PKey::RSA).to receive(:new).with('mock key content').and_return('mock key')
-        allow(OpenSSL::X509::Certificate).to receive(:new).with('mock cert content').and_return('mock cert')
+        allow(OpenSSL::PKey::RSA).to receive(:new).with('BGS_KEY_LOCATION').and_return('mock key')
+        allow(OpenSSL::X509::Certificate).to receive(:new).with('BGS_CERT_LOCATION').and_return('mock cert')
 
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
-
-        stub_request(:post, url)
+        stub_request(:post, upload_url)
           .with(
             headers: {
               'Accept' => '*/*',
               'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'Authorization' => 'Bearer fake.jwt.token',
               'Content-Type' => 'multipart/form-data',
-              'Host' => 'fake.api.claimevidence.comapi',
+              'Host' => 'fake.api.claimevidence.com',
+              'User-Agent' => 'Ruby',
+              'X-Folder-Uri' => 'VETERAN:FILENUMBER:500000000'
+            }
+          ).to_return(status: 200, body: '', headers: {})
+
+          stub_request(:post, update_url)
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Content-Type' => 'multipart/form-data',
+              'Host' => 'fake.api.claimevidence.com',
               'User-Agent' => 'Ruby',
               'X-Folder-Uri' => 'VETERAN:FILENUMBER:500000000'
             }
@@ -264,66 +275,60 @@ describe ExternalApi::ClaimEvidenceService do
       end
 
       it 'uploads document' do
-        ExternalApi::ClaimEvidenceService.upload_document(file, file_number, doc_info)
-        expect(WebMock).to have_requested(:post, url)
+        described_class.new.upload_document(file, file_number, doc_info)
+        expect(WebMock).to have_requested(:post, upload_url)
       end
 
       it 'updates document' do
-        ExternalApi::ClaimEvidenceService.update_document(
+        described_class.new.update_document(
           veteran_file_number: file_number,
-          file_uuid: "123456789",
+          file_uuid: '123456789',
           file_update_payload: ClaimEvidenceFileUpdatePayload.new(
-            date_va_received_document: Time.zone.now,
-            document_type_id: uploadable_document.document_type_id,
-            file_content_path: uploadable_document.pdf_location,
-            file_content_source: uploadable_document.source
+            date_va_received_document: Time.current,
+            document_type_id: 'abc123',
+            file_content_path: '/path/to/doc',
+            file_content_source: 'encoded-string'
           )
         )
-        expect(WebMock).to have_requested(:post, url)
+        expect(WebMock).to have_requested(:post, update_url)
       end
     end
   end
 
   context 'response failure' do
-    subject { ExternalApi::ClaimEvidenceService.document_types }
     context 'throws fallback error' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceApiError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(error_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceApiError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceApiError
       end
     end
 
     context '401' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(unauthorized_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError
       end
     end
 
     context '403' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(forbidden_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError
       end
     end
 
     context '404' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(not_found_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError
       end
     end
 
     context '500' do
       let!(:error_code) { 500 }
       it 'throws ClaimEvidenceApi::Error:ClaimEvidenceInternalServerError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(internal_server_error_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceInternalServerError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceInternalServerError
       end
     end
   end
@@ -402,7 +407,6 @@ describe ExternalApi::ClaimEvidenceService do
 
   #   it 'retrieves key_phrases from CE API document' do
   #     subject.aws_stub_client.stub_responses(:detect_key_phrases, { key_phrases: stub_response })
-  #     allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
   #     allow(HTTPI).to receive(:get).and_return(success_get_raw_ocr_document_response)
   #     output = subject.get_key_phrases_from_document(doc_uuid, stub_response: true)
   #     expect(output).to eq(%W[Department APPEAL\n1A])

--- a/spec/external_api/veteran_file_fetcher_spec.rb
+++ b/spec/external_api/veteran_file_fetcher_spec.rb
@@ -16,9 +16,15 @@ describe ExternalApi::VeteranFileFetcher do
     )
   end
 
+  let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
+
+  before do
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+  end
+
   describe '#fetch_veteran_file_list' do
     it 'calls the API endpoint' do
-      expect(ExternalApi::ClaimEvidenceService).to receive(:send_ce_api_request)
+      expect(mock_claim_evidence_service).to receive(:send_ce_api_request)
         .with(
           endpoint: '/folders/files:search',
           query: {},

--- a/spec/external_api/veteran_file_updater_spec.rb
+++ b/spec/external_api/veteran_file_updater_spec.rb
@@ -11,10 +11,15 @@ describe ExternalApi::VeteranFileUpdater do
   subject(:described) { described_class.new(use_canned_api_responses: false) }
 
   let(:mock_api_response) { instance_double(ExternalApi::Response) }
+  let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
+
+  before do
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+  end
 
   describe '#update_veteran_file' do
     it 'calls the API endpoint' do
-      expect(ExternalApi::ClaimEvidenceService).to receive(:update_document)
+      expect(mock_claim_evidence_service).to receive(:update_document)
         .with(
           veteran_file_number: '123456789',
           file_uuid: '0003E65D-0000-C118-A964-CA1AEC2925E6',

--- a/spec/external_api/veteran_file_uploader_spec.rb
+++ b/spec/external_api/veteran_file_uploader_spec.rb
@@ -21,6 +21,11 @@ describe ExternalApi::VeteranFileUploader do
       new_mail: true
     )
   end
+  let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
+
+  before do
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+  end
 
   describe '#upload_veteran_file' do
     it 'calls the API endpoint with the correct parameters' do
@@ -35,7 +40,7 @@ describe ExternalApi::VeteranFileUploader do
         }
       }
 
-      expect(ExternalApi::ClaimEvidenceService).to receive(:upload_document)
+      expect(mock_claim_evidence_service).to receive(:upload_document)
         .with(
           'path/to/test.pdf',
           '123456789',


### PR DESCRIPTION
- Update ClaimEvidenceService methods to be instance methods instead of class methods.

- Add an initialize method to ClaimEvidenceService and use it to set config from environment + set a claim_evidence_request variable in preparation for later work.

- Update specs and other classes to accommodate the changes in ClaimEvidenceService.