### PR TITLE
Fix Indentation

### DIFF
--- a/lib/ruby_claim_evidence_api.rb
+++ b/lib/ruby_claim_evidence_api.rb
@@ -12,6 +12,7 @@ require 'ruby_claim_evidence_api/external_api/veteran_file_uploader'
 # Models
 require 'ruby_claim_evidence_api/models/claim_evidence_file_update_payload'
 require 'ruby_claim_evidence_api/models/claim_evidence_file_upload_payload'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 
 # Fakes
 require 'ruby_claim_evidence_api/fakes/claim_evidence_service'

--- a/lib/ruby_claim_evidence_api/api_base.rb
+++ b/lib/ruby_claim_evidence_api/api_base.rb
@@ -15,15 +15,11 @@ class ApiBase
   attr_accessor :use_canned_api_responses, :logger
 
   def api_client
-    return @api_client unless @api_client.nil?
-
-    @api_client = if use_canned_api_responses
-                    MockApiClient.new
-                  else
-                    ExternalApi::ClaimEvidenceService.new
-                  end
-
-    @api_client
+    if use_canned_api_responses
+      MockApiClient.new
+    else
+      ExternalApi::ClaimEvidenceService.new
+    end
   end
 
   def x_folder_uri_header(veteran_file_number)

--- a/lib/ruby_claim_evidence_api/api_base.rb
+++ b/lib/ruby_claim_evidence_api/api_base.rb
@@ -20,7 +20,7 @@ class ApiBase
     @api_client = if use_canned_api_responses
                     MockApiClient.new
                   else
-                    ExternalApi::ClaimEvidenceService
+                    ExternalApi::ClaimEvidenceService.new
                   end
 
     @api_client

--- a/lib/ruby_claim_evidence_api/api_base.rb
+++ b/lib/ruby_claim_evidence_api/api_base.rb
@@ -14,11 +14,11 @@ class ApiBase
 
   attr_accessor :use_canned_api_responses, :logger
 
-  def api_client
+  def api_client(claim_evidence_request:)
     if use_canned_api_responses
       MockApiClient.new
     else
-      ExternalApi::ClaimEvidenceService.new
+      ExternalApi::ClaimEvidenceService.new(claim_evidence_request: claim_evidence_request)
     end
   end
 

--- a/lib/ruby_claim_evidence_api/claim_evidence.rb
+++ b/lib/ruby_claim_evidence_api/claim_evidence.rb
@@ -1,1 +1,0 @@
-ClaimEvidenceService = (!ApplicationController.dependencies_faked? ? ExternalApi::ClaimEvidenceService : Fakes::ClaimEvidenceService)

--- a/lib/ruby_claim_evidence_api/external_api/claim_evidence_service.rb
+++ b/lib/ruby_claim_evidence_api/external_api/claim_evidence_service.rb
@@ -24,10 +24,10 @@ module ExternalApi
     FILES_CONTENT_PATH = '/files/:uuid/content'
     FOLDERS_FILES_SEARCH_PATH = '/folders/files:search'
 
-    def initialize
+    def initialize(claim_evidence_request:)
       self.base_url = ENV['CLAIM_EVIDENCE_API_URL']
       self.cert_file_location = ENV['SSL_CERT_FILE']
-      self.claim_evidence_request = nil
+      self.claim_evidence_request = claim_evidence_request
       self.token_issuer = ENV['CLAIM_EVIDENCE_ISSUER']
       self.token_secret = ENV['CLAIM_EVIDENCE_SECRET']
       self.token_station_id = ENV['CLAIM_EVIDENCE_STATION_ID']
@@ -287,8 +287,8 @@ module ExternalApi
         iat: current_timestamp,
         iss: token_issuer,
         applicationID: token_issuer,
-        userID: token_user,
-        stationID: token_station_id
+        userID: claim_evidence_request.user_css_id,
+        stationID: claim_evidence_request.station_id
       }
       stringified_header = header.to_json.encode('UTF-8')
       encoded_header = base64url(stringified_header)

--- a/lib/ruby_claim_evidence_api/external_api/claim_evidence_service.rb
+++ b/lib/ruby_claim_evidence_api/external_api/claim_evidence_service.rb
@@ -34,147 +34,129 @@ module ExternalApi
       self.token_user = ENV['CLAIM_EVIDENCE_VBMS_USER']
     end
 
-      def document_types_request
-        {
-          headers: HEADERS,
-          endpoint: DOCUMENT_TYPES_ENDPOINT,
-          method: :get
-        }
-      end
+    def document_types_request
+      {
+        headers: HEADERS,
+        endpoint: DOCUMENT_TYPES_ENDPOINT,
+        method: :get
+      }
+    end
 
-      def ocr_document_request(doc_uuid)
-        {
-          headers: HEADERS,
-          endpoint: "/files/#{doc_uuid}/data/ocr",
-          method: :get
-        }
-      end
+    def ocr_document_request(doc_uuid)
+      {
+        headers: HEADERS,
+        endpoint: "/files/#{doc_uuid}/data/ocr",
+        method: :get
+      }
+    end
 
-      def upload_document_request(file_path, vet_file_number, doc_info)
-        request = set_upload_document_form_data_for_request(
-          request: Net::HTTP::Post.new(file_upload_uri),
-          payload: doc_info,
-          file_path: file_path
+    def upload_document_request(file_path, vet_file_number, doc_info)
+      request = set_upload_document_form_data_for_request(
+        request: Net::HTTP::Post.new(file_upload_uri),
+        payload: doc_info,
+        file_path: file_path
+      )
+
+      jwt_token = generate_jwt_token
+      request['Authorization'] = "Bearer #{jwt_token}"
+      request['X-Folder-URI'] = "VETERAN:FILENUMBER:#{vet_file_number}"
+
+      request
+    end
+
+    def update_document_request(veteran_file_number:, file_uuid:, file_update_payload:)
+      request = set_upload_document_form_data_for_request(
+        request: Net::HTTP::Post.new(file_update_uri(file_uuid)),
+        payload: {
+          providerData: {
+            contentSource: file_update_payload.file_content_source,
+            documentTypeId: file_update_payload.document_type_id,
+            dateVaReceivedDocument: file_update_payload.date_va_received_document,
+            subject: file_update_payload.subject
+          }
+        },
+        file_path: file_update_payload.file_content_path
+      )
+
+      request['Authorization'] = "Bearer #{generate_jwt_token}"
+      request['X-Folder-URI'] = "VETERAN:FILENUMBER:#{veteran_file_number}"
+
+      request
+    end
+
+    def document_types
+      send_ce_api_request(document_types_request).body['documentTypes']
+    end
+
+    def alt_document_types
+      send_ce_api_request(document_types_request).body['alternativeDocumentTypes']
+    end
+
+    def get_ocr_document(doc_uuid)
+      send_ce_api_request(ocr_document_request(doc_uuid)).body['currentVersion']['file']['text']
+    end
+
+    def upload_document(file, vet_file_number, doc_info)
+      send_multipart_post_request(upload_document_request(file, vet_file_number, doc_info)).body
+    end
+
+    def update_document(veteran_file_number:, file_uuid:, file_update_payload:)
+      send_multipart_post_request(
+        update_document_request(
+          veteran_file_number: veteran_file_number,
+          file_uuid: file_uuid,
+          file_update_payload: file_update_payload
         )
+      ).body
+    end
 
-        jwt_token = generate_jwt_token
-        request['Authorization'] = "Bearer #{jwt_token}"
-        request['X-Folder-URI'] = "VETERAN:FILENUMBER:#{vet_file_number}"
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
+    def send_multipart_post_request(request)
+      # Create Net::HTTP and configure
+      http = Net::HTTP.new(request.uri.host, request.uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
-        request
-      end
+      http.ssl_version = :TLSv1_2
+      http.ca_file = cert_file_location
+      http.cert = OpenSSL::X509::Certificate.new(File.read(ENV['BGS_CERT_LOCATION']))
+      http.key = OpenSSL::PKey::RSA.new(File.read(ENV['BGS_KEY_LOCATION']))
 
-      def update_document_request(veteran_file_number:, file_uuid:, file_update_payload:)
-        request = set_upload_document_form_data_for_request(
-          request: Net::HTTP::Post.new(file_update_uri(file_uuid)),
-          payload: {
-            providerData: {
-              contentSource: file_update_payload.file_content_source,
-              documentTypeId: file_update_payload.document_type_id,
-              dateVaReceivedDocument: file_update_payload.date_va_received_document,
-              subject: file_update_payload.subject
-            }
-          },
-          file_path: file_update_payload.file_content_path
-        )
-
-        request['Authorization'] = "Bearer #{generate_jwt_token}"
-        request['X-Folder-URI'] = "VETERAN:FILENUMBER:#{veteran_file_number}"
-
-        request
-      end
-
-      def document_types
-        send_ce_api_request(document_types_request).body['documentTypes']
-      end
-
-      def alt_document_types
-        send_ce_api_request(document_types_request).body['alternativeDocumentTypes']
-      end
-
-      def get_ocr_document(doc_uuid)
-        send_ce_api_request(ocr_document_request(doc_uuid)).body['currentVersion']['file']['text']
-      end
-
-      def upload_document(file, vet_file_number, doc_info)
-        send_multipart_post_request(upload_document_request(file, vet_file_number, doc_info)).body
-      end
-
-      def update_document(veteran_file_number:, file_uuid:, file_update_payload:)
-        send_multipart_post_request(
-          update_document_request(
-            veteran_file_number: veteran_file_number,
-            file_uuid: file_uuid,
-            file_update_payload: file_update_payload
-          )
-        ).body
-      end
-
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
-      def send_multipart_post_request(request)
-        # Create Net::HTTP and configure
-        http = Net::HTTP.new(request.uri.host, request.uri.port)
-        http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-
-        http.ssl_version = :TLSv1_2
-        http.ca_file = cert_file_location
-        http.cert = OpenSSL::X509::Certificate.new(File.read(ENV['BGS_CERT_LOCATION']))
-        http.key = OpenSSL::PKey::RSA.new(File.read(ENV['BGS_KEY_LOCATION']))
-
-        # Send Request
-        if Object.const_defined?('MetricsService')
-          MetricsService.record("api.claim.evidence POST request to '#{base_url}#{SERVER}/files'",
-                                service: :claim_evidence,
-                                name: '/files') do
-            handle_http_response(http, request)
-          end
-        else
+      # Send Request
+      if Object.const_defined?('MetricsService')
+        MetricsService.record("api.claim.evidence POST request to '#{base_url}#{SERVER}/files'",
+                              service: :claim_evidence,
+                              name: '/files') do
           handle_http_response(http, request)
         end
+      else
+        handle_http_response(http, request)
       end
+    end
 
-      # rubocop:disable Metrics/PerceivedComplexity
-      def send_ce_api_request(endpoint:, query: {}, headers: {}, method: :get, body: nil)
-        jwt_token = generate_jwt_token
+    # rubocop:disable Metrics/PerceivedComplexity
+    def send_ce_api_request(endpoint:, query: {}, headers: {}, method: :get, body: nil)
+      jwt_token = generate_jwt_token
 
-        url = URI::DEFAULT_PARSER.escape(base_url + SERVER + endpoint)
-        request = HTTPI::Request.new(url)
-        request.query = query
-        request.open_timeout = 30
-        request.read_timeout = 30
-        request.body = body.to_json unless body.nil?
-        request.auth.ssl.ssl_version  = :TLSv1_2
-        request.auth.ssl.ca_cert_file = cert_file_location
-        request.auth.ssl.cert_file = ENV['BGS_CERT_LOCATION']
-        request.auth.ssl.cert_key_file = ENV['BGS_KEY_LOCATION']
-        request.headers = headers.merge(Authorization: "Bearer #{jwt_token}")
+      url = URI::DEFAULT_PARSER.escape(base_url + SERVER + endpoint)
+      request = HTTPI::Request.new(url)
+      request.query = query
+      request.open_timeout = 30
+      request.read_timeout = 30
+      request.body = body.to_json unless body.nil?
+      request.auth.ssl.ssl_version  = :TLSv1_2
+      request.auth.ssl.ca_cert_file = cert_file_location
+      request.auth.ssl.cert_file = ENV['BGS_CERT_LOCATION']
+      request.auth.ssl.cert_key_file = ENV['BGS_KEY_LOCATION']
+      request.headers = headers.merge(Authorization: "Bearer #{jwt_token}")
 
-        sleep 1
+      sleep 1
 
-        # Check to see if MetricsService class exists. Required for Caseflow
-        if Object.const_defined?('MetricsService')
-          MetricsService.record("api.claim.evidence #{method.to_s.upcase} request to #{url}",
-                                service: :claim_evidence,
-                                name: endpoint) do
-            case method
-            when :get
-              response = HTTPI.get(request)
-              service_response = ExternalApi::Response.new(response, request)
-              fail service_response.error if service_response.error.present?
-
-              service_response
-            when :post
-              response = HTTPI.post(request)
-              service_response = ExternalApi::Response.new(response, request)
-              fail service_response.error if service_response.error.present?
-
-              service_response
-            else
-              fail NotImplementedError
-            end
-          end
-        else
+      # Check to see if MetricsService class exists. Required for Caseflow
+      if Object.const_defined?('MetricsService')
+        MetricsService.record("api.claim.evidence #{method.to_s.upcase} request to #{url}",
+                              service: :claim_evidence,
+                              name: endpoint) do
           case method
           when :get
             response = HTTPI.get(request)
@@ -192,120 +174,138 @@ module ExternalApi
             fail NotImplementedError
           end
         end
-      end
-      # rubocop:enable Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/CyclomaticComplexity
-
-
-      # REGION = ENV['AWS_REGION']
-      # AWS_COMPREHEND_SCORE = ENV['AWS_COMPREHEND_SCORE']
-
-      # def aws_client
-      #   @aws_client ||= Aws::Comprehend::Client.new(
-      #     region: REGION
-      #   )
-      # end
-
-      # def aws_stub_client
-      #   @aws_stub_client ||= Aws::Comprehend::Client.new(
-      #     region: REGION,
-      #     stub_responses: true
-      #   )
-      # end
-
-      # def get_key_phrases(ocr_data, stub_response: false)
-      #   key_phrase_parameters = {
-      #     text: ocr_data,
-      #     language_code: 'en'
-      #   }
-      #   if stub_response == true
-      #     aws_stub_client.detect_key_phrases(key_phrase_parameters).key_phrases
-      #   else
-      #     aws_client.detect_key_phrases(key_phrase_parameters).key_phrases
-      #   end
-      # end
-
-      # def filter_key_phrases_by_score(key_phrases)
-      #   key_phrases.filter_map do |key_phrase|
-      #     key_phrase[:text] if !key_phrase[:score].nil? && key_phrase[:score] >= AWS_COMPREHEND_SCORE.to_f
-      #   end
-      # end
-
-      # def get_key_phrases_from_document(doc_uuid, stub_response: false)
-      #   ocr_data = get_ocr_document(doc_uuid)
-
-      #   return unless ocr_data.present?
-
-      #   key_phrases = get_key_phrases(ocr_data, stub_response: stub_response)
-      #   filter_key_phrases_by_score(key_phrases)
-      # end
-
-      private
-
-      attr_accessor :base_url,
-                    :cert_file_location,
-                    :claim_evidence_request,
-                    :token_issuer,
-                    :token_secret,
-                    :token_station_id,
-                    :token_user
-
-      def handle_http_response(http, request)
-        http.start do |https|
-          response = https.request(request)
-          service_response = ExternalApi::Response.new(response, request, uses_net_http: true)
+      else
+        case method
+        when :get
+          response = HTTPI.get(request)
+          service_response = ExternalApi::Response.new(response, request)
           fail service_response.error if service_response.error.present?
 
-          return service_response
+          service_response
+        when :post
+          response = HTTPI.post(request)
+          service_response = ExternalApi::Response.new(response, request)
+          fail service_response.error if service_response.error.present?
+
+          service_response
+        else
+          fail NotImplementedError
         end
       end
+    end
+    # rubocop:enable Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/CyclomaticComplexity
 
-      def set_upload_document_form_data_for_request(request:, payload:, file_path:)
-        file_content = File.binread(file_path)
-        form_data = []
-        form_data << ['file', file_content, { filename: File.basename(file_path), content_type: 'application/pdf' }]
-        form_data << ['payload', payload.to_json]
-        request.set_form form_data, 'multipart/form-data'
-        request
+
+    # REGION = ENV['AWS_REGION']
+    # AWS_COMPREHEND_SCORE = ENV['AWS_COMPREHEND_SCORE']
+
+    # def aws_client
+    #   @aws_client ||= Aws::Comprehend::Client.new(
+    #     region: REGION
+    #   )
+    # end
+
+    # def aws_stub_client
+    #   @aws_stub_client ||= Aws::Comprehend::Client.new(
+    #     region: REGION,
+    #     stub_responses: true
+    #   )
+    # end
+
+    # def get_key_phrases(ocr_data, stub_response: false)
+    #   key_phrase_parameters = {
+    #     text: ocr_data,
+    #     language_code: 'en'
+    #   }
+    #   if stub_response == true
+    #     aws_stub_client.detect_key_phrases(key_phrase_parameters).key_phrases
+    #   else
+    #     aws_client.detect_key_phrases(key_phrase_parameters).key_phrases
+    #   end
+    # end
+
+    # def filter_key_phrases_by_score(key_phrases)
+    #   key_phrases.filter_map do |key_phrase|
+    #     key_phrase[:text] if !key_phrase[:score].nil? && key_phrase[:score] >= AWS_COMPREHEND_SCORE.to_f
+    #   end
+    # end
+
+    # def get_key_phrases_from_document(doc_uuid, stub_response: false)
+    #   ocr_data = get_ocr_document(doc_uuid)
+
+    #   return unless ocr_data.present?
+
+    #   key_phrases = get_key_phrases(ocr_data, stub_response: stub_response)
+    #   filter_key_phrases_by_score(key_phrases)
+    # end
+
+    private
+
+    attr_accessor :base_url,
+                  :cert_file_location,
+                  :claim_evidence_request,
+                  :token_issuer,
+                  :token_secret,
+                  :token_station_id,
+                  :token_user
+
+    def handle_http_response(http, request)
+      http.start do |https|
+        response = https.request(request)
+        service_response = ExternalApi::Response.new(response, request, uses_net_http: true)
+        fail service_response.error if service_response.error.present?
+
+        return service_response
       end
+    end
 
-      def file_upload_uri
-        @file_upload_uri = URI("#{base_url}#{SERVER}/files")
-      end
+    def set_upload_document_form_data_for_request(request:, payload:, file_path:)
+      file_content = File.binread(file_path)
+      form_data = []
+      form_data << ['file', file_content, { filename: File.basename(file_path), content_type: 'application/pdf' }]
+      form_data << ['payload', payload.to_json]
+      request.set_form form_data, 'multipart/form-data'
+      request
+    end
 
-      def file_update_uri(file_uuid)
-        @file_update_uri = URI("#{base_url}#{SERVER}/files/#{file_uuid}")
-      end
+    def file_upload_uri
+      @file_upload_uri = URI("#{base_url}#{SERVER}/files")
+    end
 
-      def generate_jwt_token
-        header = {
-          typ: 'JWT',
-          alg: 'HS256'
-        }
-        current_timestamp = DateTime.now.strftime('%Q').to_i / 1000.floor
-        data = {
-          jti: SecureRandom.uuid,
-          iat: current_timestamp,
-          iss: token_issuer,
-          applicationID: token_issuer,
-          userID: token_user,
-          stationID: token_station_id
-        }
-        stringified_header = header.to_json.encode('UTF-8')
-        encoded_header = base64url(stringified_header)
-        stringified_data = data.to_json.encode('UTF-8')
-        encoded_data = base64url(stringified_data)
-        token = "#{encoded_header}.#{encoded_data}"
-        signature = OpenSSL::HMAC.digest('SHA256', token_secret, token)
+    def file_update_uri(file_uuid)
+      @file_update_uri = URI("#{base_url}#{SERVER}/files/#{file_uuid}")
+    end
 
-        "#{token}.#{base64url(signature)}"
-      end
+    def generate_jwt_token
+      header = {
+        typ: 'JWT',
+        alg: 'HS256'
+      }
+      current_timestamp = DateTime.now.strftime('%Q').to_i / 1000.floor
+      data = {
+        jti: SecureRandom.uuid,
+        iat: current_timestamp,
+        iss: token_issuer,
+        applicationID: token_issuer,
+        userID: token_user,
+        stationID: token_station_id
+      }
+      stringified_header = header.to_json.encode('UTF-8')
+      encoded_header = base64url(stringified_header)
+      stringified_data = data.to_json.encode('UTF-8')
+      encoded_data = base64url(stringified_data)
+      token = "#{encoded_header}.#{encoded_data}"
+      signature = OpenSSL::HMAC.digest('SHA256', token_secret, token)
 
-      def base64url(source)
-        encoded_source = Base64.strict_encode64(source)
-        encoded_source = encoded_source.sub(/=+$/, '')
-        encoded_source = encoded_source.tr('+', '-')
-        encoded_source.tr('/', '_')
-      end
+      "#{token}.#{base64url(signature)}"
+    end
+
+    def base64url(source)
+      encoded_source = Base64.strict_encode64(source)
+      encoded_source = encoded_source.sub(/=+$/, '')
+      encoded_source = encoded_source.tr('+', '-')
+      encoded_source.tr('/', '_')
+    end
   end
   # rubocop:enable Metrics/ClassLength, Metrics/MethodLength
 end

--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
@@ -5,8 +5,8 @@ require 'ruby_claim_evidence_api/api_base'
 module ExternalApi
   # Updates documents in the CE API documents for a given veteran
   class VeteranFileUpdater < ApiBase
-    def update_veteran_file(veteran_file_number:, file_uuid:, file_update_payload:)
-      api_client.update_document(
+    def update_veteran_file(veteran_file_number:, claim_evidence_request:, file_uuid:, file_update_payload:)
+      api_client(claim_evidence_request: claim_evidence_request).update_document(
         veteran_file_number: veteran_file_number,
         file_uuid: file_uuid,
         file_update_payload: file_update_payload

--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_uploader.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_uploader.rb
@@ -5,8 +5,8 @@ require 'ruby_claim_evidence_api/api_base'
 module ExternalApi
   # upload documents through CE API for a given veteran
   class VeteranFileUploader < ApiBase
-    def upload_veteran_file(file_path:, veteran_file_number:, doc_info:)
-      api_client.upload_document(
+    def upload_veteran_file(file_path:, claim_evidence_request:, veteran_file_number:, doc_info:)
+      api_client(claim_evidence_request: claim_evidence_request).upload_document(
         file_path,
         veteran_file_number,
         file_upload_payload(doc_info)

--- a/lib/ruby_claim_evidence_api/models/claim_evidence_request.rb
+++ b/lib/ruby_claim_evidence_api/models/claim_evidence_request.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Encapsulates all of the data required to perform a file upload in the CE API
+# Encapsulates request-specific data (i.e., user credentials) for use in CE API requests
 class ClaimEvidenceRequest
   attr_accessor :user_css_id,
                 :station_id

--- a/lib/ruby_claim_evidence_api/models/claim_evidence_request.rb
+++ b/lib/ruby_claim_evidence_api/models/claim_evidence_request.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Encapsulates all of the data required to perform a file upload in the CE API
+class ClaimEvidenceRequest
+  attr_accessor :user_css_id,
+                :station_id
+
+  def initialize(params = {})
+    self.user_css_id = params[:user_css_id] || ''
+    self.station_id = params[:station_id] || ''
+  end
+end

--- a/spec/api_base_spec.rb
+++ b/spec/api_base_spec.rb
@@ -16,7 +16,7 @@ describe ApiBase do
     let(:described) { described_class.new(use_canned_api_responses: false) }
 
     it 'uses the actual API client' do
-      expect(described.send(:api_client).new).to be_a ExternalApi::ClaimEvidenceService
+      expect(described.send(:api_client)).to be_an_instance_of ExternalApi::ClaimEvidenceService
     end
   end
 end

--- a/spec/api_base_spec.rb
+++ b/spec/api_base_spec.rb
@@ -1,14 +1,22 @@
 # frozen_string_literal: true
 
 require 'ruby_claim_evidence_api/api_base'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 require './spec/external_api/spec_helper'
 
 describe ApiBase do
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_999',
+      station_id: 123
+    )
+  end
+
   context 'when canned API responses are used' do
     let(:described) { described_class.new(use_canned_api_responses: true) }
 
     it 'uses a mock API client' do
-      expect(described.send(:api_client)).to be_an_instance_of MockApiClient
+      expect(described.send(:api_client, { claim_evidence_request: claim_evidence_request })).to be_an_instance_of MockApiClient
     end
   end
 
@@ -16,7 +24,9 @@ describe ApiBase do
     let(:described) { described_class.new(use_canned_api_responses: false) }
 
     it 'uses the actual API client' do
-      expect(described.send(:api_client)).to be_an_instance_of ExternalApi::ClaimEvidenceService
+      expect(
+        described.send(:api_client, { claim_evidence_request: claim_evidence_request })
+      ).to be_an_instance_of ExternalApi::ClaimEvidenceService
     end
   end
 end

--- a/spec/external_api/claim_evidence_service_spec.rb
+++ b/spec/external_api/claim_evidence_service_spec.rb
@@ -3,6 +3,7 @@
 require 'httpi'
 require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/models/claim_evidence_file_update_payload'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 # require 'aws-sdk'
 require './spec/external_api/spec_helper'
 require 'webmock/rspec'
@@ -31,6 +32,12 @@ describe ExternalApi::ClaimEvidenceService do
         }
       }
     }
+  end
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_858',
+      station_id: 273
+    )
   end
 
   before do
@@ -222,19 +229,19 @@ describe ExternalApi::ClaimEvidenceService do
   context 'response success' do
     it 'document types' do
       allow(HTTPI).to receive(:get).and_return(success_doc_types_response)
-      document_types = described_class.new.document_types
+      document_types = described_class.new(claim_evidence_request: claim_evidence_request).document_types
       expect(document_types).to be_present
     end
 
     it 'alt_document_types' do
       allow(HTTPI).to receive(:get).and_return(success_alt_doc_types_response)
-      alt_document_types = described_class.new.alt_document_types
+      alt_document_types = described_class.new(claim_evidence_request: claim_evidence_request).alt_document_types
       expect(alt_document_types).to be_present
     end
 
     it 'get_ocr_document' do
       allow(HTTPI).to receive(:get).and_return(success_get_raw_ocr_document_response)
-      get_ocr_document = described_class.new.get_ocr_document(doc_uuid)
+      get_ocr_document = described_class.new(claim_evidence_request: claim_evidence_request).get_ocr_document(doc_uuid)
       expect(get_ocr_document).to be_present
       expect(get_ocr_document).to eq('Lorem ipsum')
     end
@@ -275,12 +282,12 @@ describe ExternalApi::ClaimEvidenceService do
       end
 
       it 'uploads document' do
-        described_class.new.upload_document(file, file_number, doc_info)
+        described_class.new(claim_evidence_request: claim_evidence_request).upload_document(file, file_number, doc_info)
         expect(WebMock).to have_requested(:post, upload_url)
       end
 
       it 'updates document' do
-        described_class.new.update_document(
+        described_class.new(claim_evidence_request: claim_evidence_request).update_document(
           veteran_file_number: file_number,
           file_uuid: '123456789',
           file_update_payload: ClaimEvidenceFileUpdatePayload.new(
@@ -299,28 +306,28 @@ describe ExternalApi::ClaimEvidenceService do
     context 'throws fallback error' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceApiError' do
         allow(HTTPI).to receive(:get).and_return(error_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceApiError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceApiError
       end
     end
 
     context '401' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError' do
         allow(HTTPI).to receive(:get).and_return(unauthorized_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError
       end
     end
 
     context '403' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError' do
         allow(HTTPI).to receive(:get).and_return(forbidden_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError
       end
     end
 
     context '404' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError' do
         allow(HTTPI).to receive(:get).and_return(not_found_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError
       end
     end
 
@@ -328,7 +335,7 @@ describe ExternalApi::ClaimEvidenceService do
       let!(:error_code) { 500 }
       it 'throws ClaimEvidenceApi::Error:ClaimEvidenceInternalServerError' do
         allow(HTTPI).to receive(:get).and_return(internal_server_error_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceInternalServerError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceInternalServerError
       end
     end
   end

--- a/spec/external_api/claim_evidence_service_spec.rb
+++ b/spec/external_api/claim_evidence_service_spec.rb
@@ -9,7 +9,6 @@ require 'webmock/rspec'
 
 describe ExternalApi::ClaimEvidenceService do
   # Fake/Testing ENV variables
-  let(:base_url) { 'https://fake.api.claimevidence.com' }
   let(:client_secret) { 'SOME-FAKE-KEY' }
   let(:doc_uuid) { 'SOME-FAKE-UUID' }
   let(:service_id) { 'SOME-FAKE-SERVICE' }
@@ -33,8 +32,20 @@ describe ExternalApi::ClaimEvidenceService do
       }
     }
   end
+
   before do
-    ExternalApi::ClaimEvidenceService::BASE_URL = base_url
+    ENV['CLAIM_EVIDENCE_SECRET'] = 'CLAIM_EVIDENCE_SECRET'
+    ENV['CLAIM_EVIDENCE_ISSUER'] = 'CLAIM_EVIDENCE_ISSUER'
+    ENV['CLAIM_EVIDENCE_VBMS_USER'] = 'CLAIM_EVIDENCE_VBMS_USER'
+    ENV['CLAIM_EVIDENCE_STATION_ID'] = 'CLAIM_EVIDENCE_STATION_ID'
+    ENV['CLAIM_EVIDENCE_API_URL'] = 'https://fake.api.claimevidence.com/'
+    ENV['SSL_CERT_FILE'] = 'SSL_CERT_FILE'
+    ENV['BGS_CERT_LOCATION'] = 'BGS_CERT_LOCATION'
+    ENV['BGS_KEY_LOCATION'] = 'BGS_KEY_LOCATION'
+
+    allow(File).to receive(:read).and_call_original
+    allow(File).to receive(:read).with('BGS_CERT_LOCATION').and_return('BGS_CERT_LOCATION')
+    allow(File).to receive(:read).with('BGS_KEY_LOCATION').and_return('BGS_KEY_LOCATION')
   end
 
   let(:doc_types_body) do
@@ -210,53 +221,53 @@ describe ExternalApi::ClaimEvidenceService do
 
   context 'response success' do
     it 'document types' do
-      allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
       allow(HTTPI).to receive(:get).and_return(success_doc_types_response)
-      document_types = ExternalApi::ClaimEvidenceService.document_types
+      document_types = described_class.new.document_types
       expect(document_types).to be_present
     end
 
     it 'alt_document_types' do
-      allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
       allow(HTTPI).to receive(:get).and_return(success_alt_doc_types_response)
-      alt_document_types = ExternalApi::ClaimEvidenceService.alt_document_types
+      alt_document_types = described_class.new.alt_document_types
       expect(alt_document_types).to be_present
     end
 
     it 'get_ocr_document' do
-      allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
       allow(HTTPI).to receive(:get).and_return(success_get_raw_ocr_document_response)
-      get_ocr_document = ExternalApi::ClaimEvidenceService.get_ocr_document(doc_uuid)
+      get_ocr_document = described_class.new.get_ocr_document(doc_uuid)
       expect(get_ocr_document).to be_present
       expect(get_ocr_document).to eq('Lorem ipsum')
     end
 
     describe 'with multipart Net HTTP request' do
-      let(:url) { 'https://fake.api.claimevidence.comapi/v1/rest/files' }
-      let(:ssl_key_path) { 'path/to/key' }
-      let(:ssl_cert_path) { 'path/to/cert' }
+      let(:upload_url) { 'https://fake.api.claimevidence.com/api/v1/rest/files' }
+      let(:update_url) { 'https://fake.api.claimevidence.com/api/v1/rest/files/123456789' }
 
       before do
-        allow(ENV).to receive(:[]).with('BGS_CERT_LOCATION').and_return(ssl_cert_path)
-        allow(ENV).to receive(:[]).with('BGS_KEY_LOCATION').and_return(ssl_key_path)
-
         allow(File).to receive(:binread).and_return("\x05\x00\x68\x65\x6c\x6c\x6f")
-        allow(File).to receive(:read).with(ssl_cert_path).and_return('mock cert content')
-        allow(File).to receive(:read).with(ssl_key_path).and_return('mock key content')
 
-        allow(OpenSSL::PKey::RSA).to receive(:new).with('mock key content').and_return('mock key')
-        allow(OpenSSL::X509::Certificate).to receive(:new).with('mock cert content').and_return('mock cert')
+        allow(OpenSSL::PKey::RSA).to receive(:new).with('BGS_KEY_LOCATION').and_return('mock key')
+        allow(OpenSSL::X509::Certificate).to receive(:new).with('BGS_CERT_LOCATION').and_return('mock cert')
 
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
-
-        stub_request(:post, url)
+        stub_request(:post, upload_url)
           .with(
             headers: {
               'Accept' => '*/*',
               'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'Authorization' => 'Bearer fake.jwt.token',
               'Content-Type' => 'multipart/form-data',
-              'Host' => 'fake.api.claimevidence.comapi',
+              'Host' => 'fake.api.claimevidence.com',
+              'User-Agent' => 'Ruby',
+              'X-Folder-Uri' => 'VETERAN:FILENUMBER:500000000'
+            }
+          ).to_return(status: 200, body: '', headers: {})
+
+          stub_request(:post, update_url)
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Content-Type' => 'multipart/form-data',
+              'Host' => 'fake.api.claimevidence.com',
               'User-Agent' => 'Ruby',
               'X-Folder-Uri' => 'VETERAN:FILENUMBER:500000000'
             }
@@ -264,66 +275,60 @@ describe ExternalApi::ClaimEvidenceService do
       end
 
       it 'uploads document' do
-        ExternalApi::ClaimEvidenceService.upload_document(file, file_number, doc_info)
-        expect(WebMock).to have_requested(:post, url)
+        described_class.new.upload_document(file, file_number, doc_info)
+        expect(WebMock).to have_requested(:post, upload_url)
       end
 
       it 'updates document' do
-        ExternalApi::ClaimEvidenceService.update_document(
+        described_class.new.update_document(
           veteran_file_number: file_number,
-          file_uuid: "123456789",
+          file_uuid: '123456789',
           file_update_payload: ClaimEvidenceFileUpdatePayload.new(
-            date_va_received_document: Time.zone.now,
-            document_type_id: uploadable_document.document_type_id,
-            file_content_path: uploadable_document.pdf_location,
-            file_content_source: uploadable_document.source
+            date_va_received_document: Time.current,
+            document_type_id: 'abc123',
+            file_content_path: '/path/to/doc',
+            file_content_source: 'encoded-string'
           )
         )
-        expect(WebMock).to have_requested(:post, url)
+        expect(WebMock).to have_requested(:post, update_url)
       end
     end
   end
 
   context 'response failure' do
-    subject { ExternalApi::ClaimEvidenceService.document_types }
     context 'throws fallback error' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceApiError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(error_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceApiError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceApiError
       end
     end
 
     context '401' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(unauthorized_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError
       end
     end
 
     context '403' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(forbidden_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError
       end
     end
 
     context '404' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(not_found_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError
       end
     end
 
     context '500' do
       let!(:error_code) { 500 }
       it 'throws ClaimEvidenceApi::Error:ClaimEvidenceInternalServerError' do
-        allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
         allow(HTTPI).to receive(:get).and_return(internal_server_error_response)
-        expect { subject }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceInternalServerError
+        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceInternalServerError
       end
     end
   end
@@ -402,7 +407,6 @@ describe ExternalApi::ClaimEvidenceService do
 
   #   it 'retrieves key_phrases from CE API document' do
   #     subject.aws_stub_client.stub_responses(:detect_key_phrases, { key_phrases: stub_response })
-  #     allow(ExternalApi::ClaimEvidenceService).to receive(:generate_jwt_token).and_return('fake.jwt.token')
   #     allow(HTTPI).to receive(:get).and_return(success_get_raw_ocr_document_response)
   #     output = subject.get_key_phrases_from_document(doc_uuid, stub_response: true)
   #     expect(output).to eq(%W[Department APPEAL\n1A])

--- a/spec/external_api/veteran_file_fetcher_spec.rb
+++ b/spec/external_api/veteran_file_fetcher_spec.rb
@@ -16,9 +16,15 @@ describe ExternalApi::VeteranFileFetcher do
     )
   end
 
+  let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
+
+  before do
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+  end
+
   describe '#fetch_veteran_file_list' do
     it 'calls the API endpoint' do
-      expect(ExternalApi::ClaimEvidenceService).to receive(:send_ce_api_request)
+      expect(mock_claim_evidence_service).to receive(:send_ce_api_request)
         .with(
           endpoint: '/folders/files:search',
           query: {},

--- a/spec/external_api/veteran_file_fetcher_spec.rb
+++ b/spec/external_api/veteran_file_fetcher_spec.rb
@@ -4,46 +4,122 @@ require 'ruby_claim_evidence_api/api_base'
 require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/external_api/response'
 require 'ruby_claim_evidence_api/external_api/veteran_file_fetcher'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 require './spec/external_api/spec_helper'
 
 describe ExternalApi::VeteranFileFetcher do
   subject(:described) { described_class.new(use_canned_api_responses: false) }
 
-  let(:mock_api_response) do
+  let(:mock_json_response) do
     instance_double(
       ExternalApi::Response,
       body: { page: { totalResults: 0, totalPages: 1, currentPage: 1 } }.with_indifferent_access
     )
   end
 
+  let(:mock_doc_content_response) do
+    instance_double(
+      ExternalApi::Response,
+      resp: mock_json_response
+    )
+  end
+
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_999',
+      station_id: 123
+    )
+  end
+
   let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
 
   before do
-    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).with(claim_evidence_request: claim_evidence_request)
+                                                             .and_return(mock_claim_evidence_service)
   end
 
   describe '#fetch_veteran_file_list' do
-    it 'calls the API endpoint' do
+    it 'sucessfully calls the API endpoint' do
       expect(mock_claim_evidence_service).to receive(:send_ce_api_request)
         .with(
           endpoint: '/folders/files:search',
           query: {},
           headers: {
-            "Content-Type": 'application/json',
-            "Accept": '*/*',
-            "X-Folder-URI": 'VETERAN:FILENUMBER:123456789'
+            'Content-Type': 'application/json',
+            'Accept': '*/*',
+            'X-Folder-URI': 'VETERAN:FILENUMBER:123456789'
           },
           method: :post,
           body: {
-            "pageRequest": {
-              "resultsPerPage": 20,
-              "page": 1
+            'pageRequest': {
+              'resultsPerPage': 20,
+              'page': 1
             },
-            "filters": {}
+            'filters': {}
           }
-        ).and_return(mock_api_response)
+        ).and_return(mock_json_response)
 
-      described.fetch_veteran_file_list(veteran_file_number: '123456789')
+      described.fetch_veteran_file_list(
+        veteran_file_number: '123456789',
+        claim_evidence_request: claim_evidence_request
+      )
+    end
+  end
+
+  describe '#fetch_veteran_file_list_by_date_range' do
+    let(:begin_date_range) { 2.weeks.ago }
+    let(:end_date_range) { 1.week.ago }
+
+    it 'sucessfully calls the API endpoint' do
+      expect(mock_claim_evidence_service).to receive(:send_ce_api_request)
+        .with(
+          endpoint: '/folders/files:search',
+          query: {},
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': '*/*',
+            'X-Folder-URI': 'VETERAN:FILENUMBER:123456789'
+          },
+          method: :post,
+          body: {
+            'pageRequest': {
+              'resultsPerPage': 20,
+              'page': 1
+            },
+            'filters': {
+              'systemData.uploadedDateTime': {
+                'evaluationType': 'BETWEEN',
+                'value': [begin_date_range, end_date_range]
+              }
+            }
+          }
+        ).and_return(mock_json_response)
+
+      described.fetch_veteran_file_list_by_date_range(
+        veteran_file_number: '123456789',
+        claim_evidence_request: claim_evidence_request,
+        begin_date_range: begin_date_range,
+        end_date_range: end_date_range
+      )
+    end
+  end
+
+  describe '#get_document_content' do
+    it 'sucessfully calls the API endpoint' do
+      expect(mock_claim_evidence_service).to receive(:send_ce_api_request)
+        .with(
+          endpoint: '/files/123456789/content',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': '*/*'
+          },
+          method: :get
+        ).and_return(mock_doc_content_response)
+
+      described.get_document_content(
+        doc_series_id: '123456789',
+        claim_evidence_request: claim_evidence_request
+      )
     end
   end
 end

--- a/spec/external_api/veteran_file_updater_spec.rb
+++ b/spec/external_api/veteran_file_updater_spec.rb
@@ -5,6 +5,7 @@ require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/external_api/response'
 require 'ruby_claim_evidence_api/external_api/veteran_file_updater'
 require 'ruby_claim_evidence_api/models/claim_evidence_file_update_payload'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 require './spec/external_api/spec_helper'
 
 describe ExternalApi::VeteranFileUpdater do
@@ -13,8 +14,16 @@ describe ExternalApi::VeteranFileUpdater do
   let(:mock_api_response) { instance_double(ExternalApi::Response) }
   let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
 
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_999',
+      station_id: 123
+    )
+  end
+
   before do
-    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).with(claim_evidence_request: claim_evidence_request)
+                                                             .and_return(mock_claim_evidence_service)
   end
 
   describe '#update_veteran_file' do
@@ -28,6 +37,7 @@ describe ExternalApi::VeteranFileUpdater do
 
       described.update_veteran_file(
         veteran_file_number: '123456789',
+        claim_evidence_request: claim_evidence_request,
         file_uuid: '0003E65D-0000-C118-A964-CA1AEC2925E6',
         file_update_payload: ClaimEvidenceFileUpdatePayload.new
       )

--- a/spec/external_api/veteran_file_updater_spec.rb
+++ b/spec/external_api/veteran_file_updater_spec.rb
@@ -11,10 +11,15 @@ describe ExternalApi::VeteranFileUpdater do
   subject(:described) { described_class.new(use_canned_api_responses: false) }
 
   let(:mock_api_response) { instance_double(ExternalApi::Response) }
+  let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
+
+  before do
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+  end
 
   describe '#update_veteran_file' do
     it 'calls the API endpoint' do
-      expect(ExternalApi::ClaimEvidenceService).to receive(:update_document)
+      expect(mock_claim_evidence_service).to receive(:update_document)
         .with(
           veteran_file_number: '123456789',
           file_uuid: '0003E65D-0000-C118-A964-CA1AEC2925E6',

--- a/spec/external_api/veteran_file_uploader_spec.rb
+++ b/spec/external_api/veteran_file_uploader_spec.rb
@@ -5,6 +5,7 @@ require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/external_api/response'
 require 'ruby_claim_evidence_api/external_api/veteran_file_uploader'
 require 'ruby_claim_evidence_api/models/claim_evidence_file_upload_payload'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 require './spec/external_api/spec_helper'
 
 describe ExternalApi::VeteranFileUploader do
@@ -22,9 +23,16 @@ describe ExternalApi::VeteranFileUploader do
     )
   end
   let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_999',
+      station_id: 123
+    )
+  end
 
   before do
-    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).with(claim_evidence_request: claim_evidence_request)
+                                                             .and_return(mock_claim_evidence_service)
   end
 
   describe '#upload_veteran_file' do
@@ -49,6 +57,7 @@ describe ExternalApi::VeteranFileUploader do
 
       veteran_file_uploader.upload_veteran_file(
         file_path: 'path/to/test.pdf',
+        claim_evidence_request: claim_evidence_request,
         veteran_file_number: '123456789',
         doc_info: doc_info
       )

--- a/spec/external_api/veteran_file_uploader_spec.rb
+++ b/spec/external_api/veteran_file_uploader_spec.rb
@@ -21,6 +21,11 @@ describe ExternalApi::VeteranFileUploader do
       new_mail: true
     )
   end
+  let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
+
+  before do
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+  end
 
   describe '#upload_veteran_file' do
     it 'calls the API endpoint with the correct parameters' do
@@ -35,7 +40,7 @@ describe ExternalApi::VeteranFileUploader do
         }
       }
 
-      expect(ExternalApi::ClaimEvidenceService).to receive(:upload_document)
+      expect(mock_claim_evidence_service).to receive(:upload_document)
         .with(
           'path/to/test.pdf',
           '123456789',


### PR DESCRIPTION
Fixing indentation in a separate PR to avoid muddling https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api/pull/87.

When the `class << self` was removed in the above PR, the indentation needed to be decreased a level throughout the file.