### PR TITLE
Send User Credentials in Claim Evidence Requests

### DIFF
--- a/lib/ruby_claim_evidence_api.rb
+++ b/lib/ruby_claim_evidence_api.rb
@@ -12,6 +12,7 @@ require 'ruby_claim_evidence_api/external_api/veteran_file_uploader'
 # Models
 require 'ruby_claim_evidence_api/models/claim_evidence_file_update_payload'
 require 'ruby_claim_evidence_api/models/claim_evidence_file_upload_payload'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 
 # Fakes
 require 'ruby_claim_evidence_api/fakes/claim_evidence_service'

--- a/lib/ruby_claim_evidence_api/api_base.rb
+++ b/lib/ruby_claim_evidence_api/api_base.rb
@@ -14,11 +14,11 @@ class ApiBase
 
   attr_accessor :use_canned_api_responses, :logger
 
-  def api_client
+  def api_client(claim_evidence_request:)
     if use_canned_api_responses
       MockApiClient.new
     else
-      ExternalApi::ClaimEvidenceService.new
+      ExternalApi::ClaimEvidenceService.new(claim_evidence_request: claim_evidence_request)
     end
   end
 

--- a/lib/ruby_claim_evidence_api/external_api/claim_evidence_service.rb
+++ b/lib/ruby_claim_evidence_api/external_api/claim_evidence_service.rb
@@ -24,10 +24,10 @@ module ExternalApi
     FILES_CONTENT_PATH = '/files/:uuid/content'
     FOLDERS_FILES_SEARCH_PATH = '/folders/files:search'
 
-    def initialize
+    def initialize(claim_evidence_request:)
       self.base_url = ENV['CLAIM_EVIDENCE_API_URL']
       self.cert_file_location = ENV['SSL_CERT_FILE']
-      self.claim_evidence_request = nil
+      self.claim_evidence_request = claim_evidence_request
       self.token_issuer = ENV['CLAIM_EVIDENCE_ISSUER']
       self.token_secret = ENV['CLAIM_EVIDENCE_SECRET']
       self.token_station_id = ENV['CLAIM_EVIDENCE_STATION_ID']
@@ -287,8 +287,8 @@ module ExternalApi
         iat: current_timestamp,
         iss: token_issuer,
         applicationID: token_issuer,
-        userID: token_user,
-        stationID: token_station_id
+        userID: claim_evidence_request.user_css_id,
+        stationID: claim_evidence_request.station_id
       }
       stringified_header = header.to_json.encode('UTF-8')
       encoded_header = base64url(stringified_header)

--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_updater.rb
@@ -5,8 +5,8 @@ require 'ruby_claim_evidence_api/api_base'
 module ExternalApi
   # Updates documents in the CE API documents for a given veteran
   class VeteranFileUpdater < ApiBase
-    def update_veteran_file(veteran_file_number:, file_uuid:, file_update_payload:)
-      api_client.update_document(
+    def update_veteran_file(veteran_file_number:, claim_evidence_request:, file_uuid:, file_update_payload:)
+      api_client(claim_evidence_request: claim_evidence_request).update_document(
         veteran_file_number: veteran_file_number,
         file_uuid: file_uuid,
         file_update_payload: file_update_payload

--- a/lib/ruby_claim_evidence_api/external_api/veteran_file_uploader.rb
+++ b/lib/ruby_claim_evidence_api/external_api/veteran_file_uploader.rb
@@ -5,8 +5,8 @@ require 'ruby_claim_evidence_api/api_base'
 module ExternalApi
   # upload documents through CE API for a given veteran
   class VeteranFileUploader < ApiBase
-    def upload_veteran_file(file_path:, veteran_file_number:, doc_info:)
-      api_client.upload_document(
+    def upload_veteran_file(file_path:, claim_evidence_request:, veteran_file_number:, doc_info:)
+      api_client(claim_evidence_request: claim_evidence_request).upload_document(
         file_path,
         veteran_file_number,
         file_upload_payload(doc_info)

--- a/lib/ruby_claim_evidence_api/models/claim_evidence_request.rb
+++ b/lib/ruby_claim_evidence_api/models/claim_evidence_request.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Encapsulates all of the data required to perform a file upload in the CE API
+# Encapsulates request-specific data (i.e., user credentials) for use in CE API requests
 class ClaimEvidenceRequest
   attr_accessor :user_css_id,
                 :station_id

--- a/spec/api_base_spec.rb
+++ b/spec/api_base_spec.rb
@@ -1,14 +1,22 @@
 # frozen_string_literal: true
 
 require 'ruby_claim_evidence_api/api_base'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 require './spec/external_api/spec_helper'
 
 describe ApiBase do
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_999',
+      station_id: 123
+    )
+  end
+
   context 'when canned API responses are used' do
     let(:described) { described_class.new(use_canned_api_responses: true) }
 
     it 'uses a mock API client' do
-      expect(described.send(:api_client)).to be_an_instance_of MockApiClient
+      expect(described.send(:api_client, { claim_evidence_request: claim_evidence_request })).to be_an_instance_of MockApiClient
     end
   end
 
@@ -16,7 +24,9 @@ describe ApiBase do
     let(:described) { described_class.new(use_canned_api_responses: false) }
 
     it 'uses the actual API client' do
-      expect(described.send(:api_client)).to be_an_instance_of ExternalApi::ClaimEvidenceService
+      expect(
+        described.send(:api_client, { claim_evidence_request: claim_evidence_request })
+      ).to be_an_instance_of ExternalApi::ClaimEvidenceService
     end
   end
 end

--- a/spec/external_api/claim_evidence_service_spec.rb
+++ b/spec/external_api/claim_evidence_service_spec.rb
@@ -3,6 +3,7 @@
 require 'httpi'
 require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/models/claim_evidence_file_update_payload'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 # require 'aws-sdk'
 require './spec/external_api/spec_helper'
 require 'webmock/rspec'
@@ -31,6 +32,12 @@ describe ExternalApi::ClaimEvidenceService do
         }
       }
     }
+  end
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_858',
+      station_id: 273
+    )
   end
 
   before do
@@ -222,19 +229,19 @@ describe ExternalApi::ClaimEvidenceService do
   context 'response success' do
     it 'document types' do
       allow(HTTPI).to receive(:get).and_return(success_doc_types_response)
-      document_types = described_class.new.document_types
+      document_types = described_class.new(claim_evidence_request: claim_evidence_request).document_types
       expect(document_types).to be_present
     end
 
     it 'alt_document_types' do
       allow(HTTPI).to receive(:get).and_return(success_alt_doc_types_response)
-      alt_document_types = described_class.new.alt_document_types
+      alt_document_types = described_class.new(claim_evidence_request: claim_evidence_request).alt_document_types
       expect(alt_document_types).to be_present
     end
 
     it 'get_ocr_document' do
       allow(HTTPI).to receive(:get).and_return(success_get_raw_ocr_document_response)
-      get_ocr_document = described_class.new.get_ocr_document(doc_uuid)
+      get_ocr_document = described_class.new(claim_evidence_request: claim_evidence_request).get_ocr_document(doc_uuid)
       expect(get_ocr_document).to be_present
       expect(get_ocr_document).to eq('Lorem ipsum')
     end
@@ -275,12 +282,12 @@ describe ExternalApi::ClaimEvidenceService do
       end
 
       it 'uploads document' do
-        described_class.new.upload_document(file, file_number, doc_info)
+        described_class.new(claim_evidence_request: claim_evidence_request).upload_document(file, file_number, doc_info)
         expect(WebMock).to have_requested(:post, upload_url)
       end
 
       it 'updates document' do
-        described_class.new.update_document(
+        described_class.new(claim_evidence_request: claim_evidence_request).update_document(
           veteran_file_number: file_number,
           file_uuid: '123456789',
           file_update_payload: ClaimEvidenceFileUpdatePayload.new(
@@ -299,28 +306,28 @@ describe ExternalApi::ClaimEvidenceService do
     context 'throws fallback error' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceApiError' do
         allow(HTTPI).to receive(:get).and_return(error_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceApiError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceApiError
       end
     end
 
     context '401' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError' do
         allow(HTTPI).to receive(:get).and_return(unauthorized_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceUnauthorizedError
       end
     end
 
     context '403' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError' do
         allow(HTTPI).to receive(:get).and_return(forbidden_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceForbiddenError
       end
     end
 
     context '404' do
       it 'throws ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError' do
         allow(HTTPI).to receive(:get).and_return(not_found_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceNotFoundError
       end
     end
 
@@ -328,7 +335,7 @@ describe ExternalApi::ClaimEvidenceService do
       let!(:error_code) { 500 }
       it 'throws ClaimEvidenceApi::Error:ClaimEvidenceInternalServerError' do
         allow(HTTPI).to receive(:get).and_return(internal_server_error_response)
-        expect { described_class.new.document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceInternalServerError
+        expect { described_class.new(claim_evidence_request: claim_evidence_request).document_types }.to raise_error ClaimEvidenceApi::Error::ClaimEvidenceInternalServerError
       end
     end
   end

--- a/spec/external_api/veteran_file_fetcher_spec.rb
+++ b/spec/external_api/veteran_file_fetcher_spec.rb
@@ -4,46 +4,122 @@ require 'ruby_claim_evidence_api/api_base'
 require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/external_api/response'
 require 'ruby_claim_evidence_api/external_api/veteran_file_fetcher'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 require './spec/external_api/spec_helper'
 
 describe ExternalApi::VeteranFileFetcher do
   subject(:described) { described_class.new(use_canned_api_responses: false) }
 
-  let(:mock_api_response) do
+  let(:mock_json_response) do
     instance_double(
       ExternalApi::Response,
       body: { page: { totalResults: 0, totalPages: 1, currentPage: 1 } }.with_indifferent_access
     )
   end
 
+  let(:mock_doc_content_response) do
+    instance_double(
+      ExternalApi::Response,
+      resp: mock_json_response
+    )
+  end
+
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_999',
+      station_id: 123
+    )
+  end
+
   let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
 
   before do
-    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).with(claim_evidence_request: claim_evidence_request)
+                                                             .and_return(mock_claim_evidence_service)
   end
 
   describe '#fetch_veteran_file_list' do
-    it 'calls the API endpoint' do
+    it 'sucessfully calls the API endpoint' do
       expect(mock_claim_evidence_service).to receive(:send_ce_api_request)
         .with(
           endpoint: '/folders/files:search',
           query: {},
           headers: {
-            "Content-Type": 'application/json',
-            "Accept": '*/*',
-            "X-Folder-URI": 'VETERAN:FILENUMBER:123456789'
+            'Content-Type': 'application/json',
+            'Accept': '*/*',
+            'X-Folder-URI': 'VETERAN:FILENUMBER:123456789'
           },
           method: :post,
           body: {
-            "pageRequest": {
-              "resultsPerPage": 20,
-              "page": 1
+            'pageRequest': {
+              'resultsPerPage': 20,
+              'page': 1
             },
-            "filters": {}
+            'filters': {}
           }
-        ).and_return(mock_api_response)
+        ).and_return(mock_json_response)
 
-      described.fetch_veteran_file_list(veteran_file_number: '123456789')
+      described.fetch_veteran_file_list(
+        veteran_file_number: '123456789',
+        claim_evidence_request: claim_evidence_request
+      )
+    end
+  end
+
+  describe '#fetch_veteran_file_list_by_date_range' do
+    let(:begin_date_range) { 2.weeks.ago }
+    let(:end_date_range) { 1.week.ago }
+
+    it 'sucessfully calls the API endpoint' do
+      expect(mock_claim_evidence_service).to receive(:send_ce_api_request)
+        .with(
+          endpoint: '/folders/files:search',
+          query: {},
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': '*/*',
+            'X-Folder-URI': 'VETERAN:FILENUMBER:123456789'
+          },
+          method: :post,
+          body: {
+            'pageRequest': {
+              'resultsPerPage': 20,
+              'page': 1
+            },
+            'filters': {
+              'systemData.uploadedDateTime': {
+                'evaluationType': 'BETWEEN',
+                'value': [begin_date_range, end_date_range]
+              }
+            }
+          }
+        ).and_return(mock_json_response)
+
+      described.fetch_veteran_file_list_by_date_range(
+        veteran_file_number: '123456789',
+        claim_evidence_request: claim_evidence_request,
+        begin_date_range: begin_date_range,
+        end_date_range: end_date_range
+      )
+    end
+  end
+
+  describe '#get_document_content' do
+    it 'sucessfully calls the API endpoint' do
+      expect(mock_claim_evidence_service).to receive(:send_ce_api_request)
+        .with(
+          endpoint: '/files/123456789/content',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': '*/*'
+          },
+          method: :get
+        ).and_return(mock_doc_content_response)
+
+      described.get_document_content(
+        doc_series_id: '123456789',
+        claim_evidence_request: claim_evidence_request
+      )
     end
   end
 end

--- a/spec/external_api/veteran_file_updater_spec.rb
+++ b/spec/external_api/veteran_file_updater_spec.rb
@@ -5,6 +5,7 @@ require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/external_api/response'
 require 'ruby_claim_evidence_api/external_api/veteran_file_updater'
 require 'ruby_claim_evidence_api/models/claim_evidence_file_update_payload'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 require './spec/external_api/spec_helper'
 
 describe ExternalApi::VeteranFileUpdater do
@@ -13,8 +14,16 @@ describe ExternalApi::VeteranFileUpdater do
   let(:mock_api_response) { instance_double(ExternalApi::Response) }
   let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
 
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_999',
+      station_id: 123
+    )
+  end
+
   before do
-    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).with(claim_evidence_request: claim_evidence_request)
+                                                             .and_return(mock_claim_evidence_service)
   end
 
   describe '#update_veteran_file' do
@@ -28,6 +37,7 @@ describe ExternalApi::VeteranFileUpdater do
 
       described.update_veteran_file(
         veteran_file_number: '123456789',
+        claim_evidence_request: claim_evidence_request,
         file_uuid: '0003E65D-0000-C118-A964-CA1AEC2925E6',
         file_update_payload: ClaimEvidenceFileUpdatePayload.new
       )

--- a/spec/external_api/veteran_file_uploader_spec.rb
+++ b/spec/external_api/veteran_file_uploader_spec.rb
@@ -5,6 +5,7 @@ require 'ruby_claim_evidence_api/external_api/claim_evidence_service'
 require 'ruby_claim_evidence_api/external_api/response'
 require 'ruby_claim_evidence_api/external_api/veteran_file_uploader'
 require 'ruby_claim_evidence_api/models/claim_evidence_file_upload_payload'
+require 'ruby_claim_evidence_api/models/claim_evidence_request'
 require './spec/external_api/spec_helper'
 
 describe ExternalApi::VeteranFileUploader do
@@ -22,9 +23,16 @@ describe ExternalApi::VeteranFileUploader do
     )
   end
   let(:mock_claim_evidence_service) { instance_double(ExternalApi::ClaimEvidenceService) }
+  let(:claim_evidence_request) do
+    ClaimEvidenceRequest.new(
+      user_css_id: 'USER_999',
+      station_id: 123
+    )
+  end
 
   before do
-    allow(ExternalApi::ClaimEvidenceService).to receive(:new).and_return(mock_claim_evidence_service)
+    allow(ExternalApi::ClaimEvidenceService).to receive(:new).with(claim_evidence_request: claim_evidence_request)
+                                                             .and_return(mock_claim_evidence_service)
   end
 
   describe '#upload_veteran_file' do
@@ -49,6 +57,7 @@ describe ExternalApi::VeteranFileUploader do
 
       veteran_file_uploader.upload_veteran_file(
         file_path: 'path/to/test.pdf',
+        claim_evidence_request: claim_evidence_request,
         veteran_file_number: '123456789',
         doc_info: doc_info
       )


### PR DESCRIPTION
- This PR updates the codebase to make use of the new `ClaimEvidenceRequest` in order to send user credentials for use in CE API requests.

- This PR builds upon work from:
  - https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api/pull/87
  - https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api/pull/88